### PR TITLE
barebones pmtiles v3 output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ tippecanoe-enumerate: enumerate.o
 tippecanoe-decode: decode.o projection.o mvt.o write_json.o text.o jsonpull/jsonpull.o dirtiles.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3
 
-tile-join: tile-join.o projection.o pool.o mbtiles.o mvt.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o
+tile-join: tile-join.o projection.o pool.o mbtiles.o mvt.o memfile.o pmtiles_file.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-json-tool: jsontool.o jsonpull/jsonpull.o csv.o text.o geojson-loop.o

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ C = $(wildcard *.c) $(wildcard *.cpp)
 INCLUDES = -I/usr/local/include -I.
 LIBS = -L/usr/local/lib
 
-tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o serial.o main.o text.o dirtiles.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o
+tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o pmtiles_file.o geometry.o projection.o memfile.o mvt.o serial.o main.o text.o dirtiles.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-enumerate: enumerate.o

--- a/main.cpp
+++ b/main.cpp
@@ -3136,18 +3136,10 @@ int main(int argc, char **argv) {
 				exit(EXIT_ARGS);
 			}
 			{
-				size_t lenstr = strlen(optarg);
-				if (lenstr < 8) {
-					fprintf(stderr, "%s: Invalid -o: %s \n", argv[0], optarg);
-					exit(EXIT_FAILURE);
-				}
-				if (strncmp(optarg+(lenstr-8),".mbtiles",8) == 0) {
-					out_mbtiles = optarg;
-				} else if (strncmp(optarg+(lenstr-8),".pmtiles",8) == 0) {
+				if (pmtiles_has_suffix(optarg)) {
 					out_pmtiles = optarg;
 				} else {
-					fprintf(stderr, "%s: Invalid -o: %s \n", argv[0], optarg);
-					exit(EXIT_FAILURE);
+					out_mbtiles = optarg;
 				}
 			}
 			break;
@@ -3499,7 +3491,7 @@ int main(int argc, char **argv) {
 			unlink(out_pmtiles);
 		}
 
-		outfile = pmtiles_open(out_pmtiles, argv, forcetable, tmpdir);
+		outfile = pmtiles_open(out_pmtiles, argv, forcetable);
 	}
 	if (out_dir != NULL) {
 		check_dir(out_dir, argv, force, forcetable);

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -16,7 +16,6 @@
 #include "mbtiles.hpp"
 #include "text.hpp"
 #include "milo/dtoa_milo.h"
-#include "write_json.hpp"
 #include "version.hpp"
 #include "errors.hpp"
 

--- a/mbtiles.hpp
+++ b/mbtiles.hpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <map>
 #include "mvt.hpp"
+#include "write_json.hpp"
 
 extern size_t max_tilestats_attributes;
 extern size_t max_tilestats_sample_values;
@@ -48,6 +49,8 @@ sqlite3 *mbtiles_open(char *dbname, char **argv, int forcetable);
 void mbtiles_write_tile(sqlite3 *outdb, int z, int tx, int ty, const char *data, int size);
 
 void mbtiles_write_metadata(sqlite3 *outdb, const char *outdir, const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double midlat, double midlon, int forcetable, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies);
+
+void tilestats(std::map<std::string, layermap_entry> const &layermap1, size_t elements, json_writer &state);
 
 void mbtiles_close(sqlite3 *outdb, const char *pgm);
 

--- a/pmtiles/pmtiles.hpp
+++ b/pmtiles/pmtiles.hpp
@@ -1,0 +1,316 @@
+#ifndef PMTILES_HPP
+#define PMTILES_HPP
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace pmtiles {
+
+struct headerv3 {
+  uint64_t root_dir_offset;
+  uint64_t root_dir_bytes;
+  uint64_t json_metadata_offset;
+  uint64_t json_metadata_bytes;
+  uint64_t leaf_dirs_offset;
+  uint64_t leaf_dirs_bytes;
+  uint64_t tile_data_offset;
+  uint64_t tile_data_bytes;
+  uint64_t addressed_tiles_count;
+  uint64_t tile_entries_count;
+  uint64_t tile_contents_count;
+  bool clustered;
+  uint8_t internal_compression;
+  uint8_t tile_compression;
+  uint8_t tile_type;
+  uint8_t min_zoom;
+  uint8_t max_zoom;
+  int32_t min_lon_e7;
+  int32_t min_lat_e7;
+  int32_t max_lon_e7;
+  int32_t max_lat_e7;
+  uint8_t center_zoom;
+  int32_t center_lon_e7;
+  int32_t center_lat_e7;
+
+  // WARNING: this is limited to little-endian
+  std::string serialize() {
+    std::stringstream ss;
+    ss << "PMTiles";
+    uint8_t version = 3;
+    ss.write((char *)&version,1);
+    ss.write((char *)&root_dir_offset,8);
+    ss.write((char *)&root_dir_bytes,8);
+    ss.write((char *)&json_metadata_offset,8);
+    ss.write((char *)&json_metadata_bytes,8);
+    ss.write((char *)&leaf_dirs_offset,8);
+    ss.write((char *)&leaf_dirs_bytes,8);
+    ss.write((char *)&tile_data_offset,8);
+    ss.write((char *)&tile_data_bytes,8);
+    ss.write((char *)&addressed_tiles_count,8);
+    ss.write((char *)&tile_entries_count,8);
+    ss.write((char *)&tile_contents_count,8);
+
+    uint8_t clustered_val = 0x0;
+    if (clustered) {
+      clustered_val = 0x1;
+    }
+
+    ss.write((char *)&clustered_val,1);
+    ss.write((char *)&internal_compression,1);
+    ss.write((char *)&tile_compression,1);
+    ss.write((char *)&tile_type,1);
+    ss.write((char *)&min_zoom,1);
+    ss.write((char *)&max_zoom,1);
+    ss.write((char *)&min_lon_e7,4);
+    ss.write((char *)&min_lat_e7,4);
+    ss.write((char *)&max_lon_e7,4);
+    ss.write((char *)&max_lat_e7,4);
+    ss.write((char *)&center_zoom,1);
+    ss.write((char *)&center_lon_e7,4);
+    ss.write((char *)&center_lat_e7,4);
+
+    return ss.str();
+  }
+};
+
+struct zxy {
+  uint8_t z;
+  uint32_t x;
+  uint32_t y;
+
+  zxy(int _z, int _x, int _y) : z(_z), x(_x), y(_y) {
+  }
+};
+
+struct entryv3 {
+  uint64_t tile_id;
+  uint64_t offset;
+  uint32_t length;
+  uint32_t run_length;
+
+  entryv3() : tile_id(0), offset(0), length(0), run_length(0) {
+  }
+
+  entryv3(uint64_t _tile_id, uint64_t _offset, uint32_t _length, uint32_t _run_length)
+    : tile_id(_tile_id), offset(_offset), length(_length), run_length(_run_length) {
+  }
+};
+
+struct {
+    bool operator()(entryv3 a, entryv3 b) const { return a.tile_id < b.tile_id; }
+} entryv3_cmp;
+
+struct varint_too_long_exception : std::exception {
+  const char* what() const noexcept override {
+    return "varint too long exception";
+  }
+};
+
+struct end_of_buffer_exception : std::exception {
+  const char* what() const noexcept override {
+      return "end of buffer exception";
+  }
+};
+
+namespace detail {
+  constexpr const int8_t max_varint_length = sizeof(uint64_t) * 8 / 7 + 1;
+
+  // from https://github.com/mapbox/protozero/blob/master/include/protozero/varint.hpp
+  inline uint64_t decode_varint_impl(const char** data, const char* end) {
+    const auto* begin = reinterpret_cast<const int8_t*>(*data);
+    const auto* iend = reinterpret_cast<const int8_t*>(end);
+    const int8_t* p = begin;
+    uint64_t val = 0;
+
+    if (iend - begin >= max_varint_length) {  // fast path
+      do {
+        int64_t b = *p++;
+                  val  = ((uint64_t(b) & 0x7fU)       ); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) <<  7U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 14U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 21U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 28U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 35U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 42U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 49U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 56U); if (b >= 0) { break; }
+        b = *p++; val |= ((uint64_t(b) & 0x01U) << 63U); if (b >= 0) { break; }
+        throw varint_too_long_exception{};
+      } while (false);
+    } else {
+      unsigned int shift = 0;
+      while (p != iend && *p < 0) {
+        val |= (uint64_t(*p++) & 0x7fU) << shift;
+        shift += 7;
+      }
+      if (p == iend) {
+        throw end_of_buffer_exception{};
+      }
+      val |= uint64_t(*p++) << shift;
+    }
+
+    *data = reinterpret_cast<const char*>(p);
+    return val;
+  }
+
+  inline uint64_t decode_varint(const char** data, const char* end) {
+    // If this is a one-byte varint, decode it here.
+    if (end != *data && ((static_cast<uint64_t>(**data) & 0x80U) == 0)) {
+      const auto val = static_cast<uint64_t>(**data);
+      ++(*data);
+      return val;
+    }
+    // If this varint is more than one byte, defer to complete implementation.
+    return detail::decode_varint_impl(data, end);
+  }
+
+  inline void rotate(int64_t n, int64_t &x, int64_t &y, int64_t rx, int64_t ry) {
+    if (ry == 0) {
+      if (rx == 1) {
+          x = n-1 - x;
+          y = n-1 - y;
+      }
+      int64_t t = x;
+      x = y;
+      y = t;
+    }
+  }
+
+  inline zxy t_on_level(uint8_t z, uint64_t pos) {
+    int64_t n = 1 << z;
+    int64_t rx, ry, s, t = pos;
+    int64_t tx = 0;
+    int64_t ty = 0;
+
+    for (s=1; s<n; s*=2) {
+      rx = 1 & (t/2);
+      ry = 1 & (t ^ rx);
+      rotate(s, tx, ty, rx, ry);
+      tx += s * rx;
+      ty += s * ry;
+      t /= 4;
+    }
+    return zxy(z,tx,ty);
+  }
+} // end namespace detail
+
+inline int write_varint(std::back_insert_iterator<std::string> data, uint64_t value) {
+  int n = 1;
+
+  while (value >= 0x80U) {
+    *data++ = char((value & 0x7fU) | 0x80U);
+    value >>= 7U;
+    ++n;
+  }
+  *data = char(value);
+
+  return n;
+}
+
+inline zxy tileid_to_zxy(uint64_t tileid) {
+  uint64_t acc = 0;
+  uint8_t t_z = 0;
+  while(true) {
+    uint64_t num_tiles = (1 << t_z) * (1 << t_z);
+    if (acc + num_tiles > tileid) {
+        return detail::t_on_level(t_z, tileid - acc);
+    }
+    acc += num_tiles;
+    t_z++;
+  }
+}
+
+inline uint64_t zxy_to_tileid(uint8_t z, uint32_t x, uint32_t y) {
+  uint64_t acc = 0;
+  for (uint8_t t_z = 0; t_z < z; t_z++) acc += (0x1 << t_z) * (0x1 << t_z);
+  int64_t n = 1 << z;
+  int64_t rx, ry, s, d=0;
+  int64_t tx = x;
+  int64_t ty = y;
+  for (s=n/2; s>0; s/=2) {
+    rx = (tx & s) > 0;
+    ry = (ty & s) > 0;
+    d += s * s * ((3 * rx) ^ ry);
+    detail::rotate(s, tx, ty, rx, ry);
+  }
+  return acc + d;
+}
+
+// returns an uncompressed byte buffer
+inline std::string serialize_directory(const std::vector<entryv3>& entries) {
+  std::string data;
+
+  write_varint(std::back_inserter(data), entries.size());
+
+  uint64_t last_id = 0;
+  for (auto const &entry : entries) {
+    write_varint(std::back_inserter(data), entry.tile_id - last_id);
+    last_id = entry.tile_id;
+  }
+
+  for (auto const &entry : entries) {
+    write_varint(std::back_inserter(data), entry.run_length);
+  }
+
+  for (auto const &entry : entries) {
+    write_varint(std::back_inserter(data), entry.length);
+  }
+
+  for (size_t i = 0; i < entries.size(); i++) {
+    if (i > 0 && entries[i].offset == entries[i-1].offset + entries[i-1].length) {
+      write_varint(std::back_inserter(data), 0);
+    } else {
+      write_varint(std::back_inserter(data), entries[i].offset+1);
+    }
+  }
+
+  return data;
+}
+
+// takes an uncompressed byte buffer
+inline std::vector<entryv3> deserialize_directory(const std::string &decompressed) {
+  const char *t = decompressed.data();
+  const char *end = t + decompressed.size();
+
+  uint64_t num_entries = detail::decode_varint(&t,end);
+
+  std::vector<entryv3> result;
+  result.resize(num_entries);
+
+  uint64_t last_id = 0;
+  for (size_t i = 0; i < num_entries; i++) {
+    uint64_t tile_id = last_id + detail::decode_varint(&t,end);
+    result[i].tile_id = tile_id;
+    last_id = tile_id;
+  }
+
+  for (size_t i = 0; i < num_entries; i++) {
+    result[i].run_length = detail::decode_varint(&t,end);
+  }
+
+  for (size_t i = 0; i < num_entries; i++) {
+    result[i].length = detail::decode_varint(&t,end);
+  }
+
+  for (size_t i = 0; i < num_entries; i++) {
+    uint64_t tmp = detail::decode_varint(&t,end);
+
+    if (i > 0 && tmp == 0) {
+      result[i].offset = result[i-1].offset + result[i-1].length;
+    } else {
+      result[i].offset = tmp - 1;
+    }
+  }
+
+  // assert the directory has been fully consumed
+  if (t != end) {
+    fprintf(stderr, "Error: malformed pmtiles directory\n");
+    exit(EXIT_FAILURE);
+  }
+
+  return result;
+}
+
+}
+#endif

--- a/pmtiles/pmtiles.hpp
+++ b/pmtiles/pmtiles.hpp
@@ -38,48 +38,100 @@ struct headerv3 {
     std::stringstream ss;
     ss << "PMTiles";
     uint8_t version = 3;
-    ss.write((char *)&version,1);
-    ss.write((char *)&root_dir_offset,8);
-    ss.write((char *)&root_dir_bytes,8);
-    ss.write((char *)&json_metadata_offset,8);
-    ss.write((char *)&json_metadata_bytes,8);
-    ss.write((char *)&leaf_dirs_offset,8);
-    ss.write((char *)&leaf_dirs_bytes,8);
-    ss.write((char *)&tile_data_offset,8);
-    ss.write((char *)&tile_data_bytes,8);
-    ss.write((char *)&addressed_tiles_count,8);
-    ss.write((char *)&tile_entries_count,8);
-    ss.write((char *)&tile_contents_count,8);
+    ss.write((char *) &version, 1);
+    ss.write((char *) &root_dir_offset, 8);
+    ss.write((char *) &root_dir_bytes, 8);
+    ss.write((char *) &json_metadata_offset, 8);
+    ss.write((char *) &json_metadata_bytes, 8);
+    ss.write((char *) &leaf_dirs_offset, 8);
+    ss.write((char *) &leaf_dirs_bytes, 8);
+    ss.write((char *) &tile_data_offset, 8);
+    ss.write((char *) &tile_data_bytes, 8);
+    ss.write((char *) &addressed_tiles_count, 8);
+    ss.write((char *) &tile_entries_count, 8);
+    ss.write((char *) &tile_contents_count, 8);
 
     uint8_t clustered_val = 0x0;
     if (clustered) {
       clustered_val = 0x1;
     }
 
-    ss.write((char *)&clustered_val,1);
-    ss.write((char *)&internal_compression,1);
-    ss.write((char *)&tile_compression,1);
-    ss.write((char *)&tile_type,1);
-    ss.write((char *)&min_zoom,1);
-    ss.write((char *)&max_zoom,1);
-    ss.write((char *)&min_lon_e7,4);
-    ss.write((char *)&min_lat_e7,4);
-    ss.write((char *)&max_lon_e7,4);
-    ss.write((char *)&max_lat_e7,4);
-    ss.write((char *)&center_zoom,1);
-    ss.write((char *)&center_lon_e7,4);
-    ss.write((char *)&center_lat_e7,4);
+    ss.write((char *) &clustered_val, 1);
+    ss.write((char *) &internal_compression, 1);
+    ss.write((char *) &tile_compression, 1);
+    ss.write((char *) &tile_type, 1);
+    ss.write((char *) &min_zoom, 1);
+    ss.write((char *) &max_zoom, 1);
+    ss.write((char *) &min_lon_e7, 4);
+    ss.write((char *) &min_lat_e7, 4);
+    ss.write((char *) &max_lon_e7, 4);
+    ss.write((char *) &max_lat_e7, 4);
+    ss.write((char *) &center_zoom, 1);
+    ss.write((char *) &center_lon_e7, 4);
+    ss.write((char *) &center_lat_e7, 4);
 
     return ss.str();
   }
 };
+
+struct pmtiles_magic_number_exception : std::exception {
+  const char *what() const noexcept override {
+    return "pmtiles magic number exception";
+  }
+};
+
+struct pmtiles_version_exception : std::exception {
+  const char *what() const noexcept override {
+    return "pmtiles version: must be 3";
+  }
+};
+
+inline headerv3 deserialize_header(const std::string &s) {
+  if (s.substr(0, 7) != "PMTiles") {
+    throw pmtiles_magic_number_exception{};
+  }
+  if (s.size() != 127 || s[7] != 0x3) {
+    throw pmtiles_version_exception{};
+  }
+  headerv3 h;
+  s.copy((char *) &h.root_dir_offset, 8, 8);
+  s.copy((char *) &h.root_dir_bytes, 8, 16);
+  s.copy((char *) &h.json_metadata_offset, 8, 24);
+  s.copy((char *) &h.json_metadata_bytes, 8, 32);
+  s.copy((char *) &h.leaf_dirs_offset, 8, 40);
+  s.copy((char *) &h.leaf_dirs_bytes, 8, 48);
+  s.copy((char *) &h.tile_data_offset, 8, 56);
+  s.copy((char *) &h.tile_data_bytes, 8, 64);
+  s.copy((char *) &h.addressed_tiles_count, 8, 72);
+  s.copy((char *) &h.tile_entries_count, 8, 80);
+  s.copy((char *) &h.tile_contents_count, 8, 88);
+  if (s[96] == 0x1) {
+    h.clustered = true;
+  } else {
+    h.clustered = false;
+  }
+  h.internal_compression = s[97];
+  h.tile_compression = s[98];
+  h.tile_type = s[99];
+  h.min_zoom = s[100];
+  h.max_zoom = s[101];
+  s.copy((char *) &h.min_lon_e7, 4, 102);
+  s.copy((char *) &h.min_lat_e7, 4, 106);
+  s.copy((char *) &h.max_lon_e7, 4, 110);
+  s.copy((char *) &h.max_lat_e7, 4, 114);
+  h.center_zoom = s[118];
+  s.copy((char *) &h.center_lon_e7, 4, 119);
+  s.copy((char *) &h.center_lat_e7, 4, 123);
+  return h;
+}
 
 struct zxy {
   uint8_t z;
   uint32_t x;
   uint32_t y;
 
-  zxy(int _z, int _x, int _y) : z(_z), x(_x), y(_y) {
+  zxy(int _z, int _x, int _y)
+      : z(_z), x(_x), y(_y) {
   }
 };
 
@@ -89,111 +141,153 @@ struct entryv3 {
   uint32_t length;
   uint32_t run_length;
 
-  entryv3() : tile_id(0), offset(0), length(0), run_length(0) {
+  entryv3()
+      : tile_id(0), offset(0), length(0), run_length(0) {
   }
 
   entryv3(uint64_t _tile_id, uint64_t _offset, uint32_t _length, uint32_t _run_length)
-    : tile_id(_tile_id), offset(_offset), length(_length), run_length(_run_length) {
+      : tile_id(_tile_id), offset(_offset), length(_length), run_length(_run_length) {
   }
 };
 
 struct {
-    bool operator()(entryv3 a, entryv3 b) const { return a.tile_id < b.tile_id; }
+  bool operator()(entryv3 a, entryv3 b) const {
+    return a.tile_id < b.tile_id;
+  }
 } entryv3_cmp;
 
 struct varint_too_long_exception : std::exception {
-  const char* what() const noexcept override {
+  const char *what() const noexcept override {
     return "varint too long exception";
   }
 };
 
 struct end_of_buffer_exception : std::exception {
-  const char* what() const noexcept override {
-      return "end of buffer exception";
+  const char *what() const noexcept override {
+    return "end of buffer exception";
   }
 };
 
 namespace detail {
-  constexpr const int8_t max_varint_length = sizeof(uint64_t) * 8 / 7 + 1;
+constexpr const int8_t max_varint_length = sizeof(uint64_t) * 8 / 7 + 1;
 
-  // from https://github.com/mapbox/protozero/blob/master/include/protozero/varint.hpp
-  inline uint64_t decode_varint_impl(const char** data, const char* end) {
-    const auto* begin = reinterpret_cast<const int8_t*>(*data);
-    const auto* iend = reinterpret_cast<const int8_t*>(end);
-    const int8_t* p = begin;
-    uint64_t val = 0;
+// from https://github.com/mapbox/protozero/blob/master/include/protozero/varint.hpp
+inline uint64_t decode_varint_impl(const char **data, const char *end) {
+  const auto *begin = reinterpret_cast<const int8_t *>(*data);
+  const auto *iend = reinterpret_cast<const int8_t *>(end);
+  const int8_t *p = begin;
+  uint64_t val = 0;
 
-    if (iend - begin >= max_varint_length) {  // fast path
-      do {
-        int64_t b = *p++;
-                  val  = ((uint64_t(b) & 0x7fU)       ); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) <<  7U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 14U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 21U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 28U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 35U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 42U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 49U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x7fU) << 56U); if (b >= 0) { break; }
-        b = *p++; val |= ((uint64_t(b) & 0x01U) << 63U); if (b >= 0) { break; }
-        throw varint_too_long_exception{};
-      } while (false);
-    } else {
-      unsigned int shift = 0;
-      while (p != iend && *p < 0) {
-        val |= (uint64_t(*p++) & 0x7fU) << shift;
-        shift += 7;
+  if (iend - begin >= max_varint_length) {  // fast path
+    do {
+      int64_t b = *p++;
+      val = ((uint64_t(b) & 0x7fU));
+      if (b >= 0) {
+        break;
       }
-      if (p == iend) {
-        throw end_of_buffer_exception{};
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 7U);
+      if (b >= 0) {
+        break;
       }
-      val |= uint64_t(*p++) << shift;
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 14U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 21U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 28U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 35U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 42U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 49U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x7fU) << 56U);
+      if (b >= 0) {
+        break;
+      }
+      b = *p++;
+      val |= ((uint64_t(b) & 0x01U) << 63U);
+      if (b >= 0) {
+        break;
+      }
+      throw varint_too_long_exception{};
+    } while (false);
+  } else {
+    unsigned int shift = 0;
+    while (p != iend && *p < 0) {
+      val |= (uint64_t(*p++) & 0x7fU) << shift;
+      shift += 7;
     }
+    if (p == iend) {
+      throw end_of_buffer_exception{};
+    }
+    val |= uint64_t(*p++) << shift;
+  }
 
-    *data = reinterpret_cast<const char*>(p);
+  *data = reinterpret_cast<const char *>(p);
+  return val;
+}
+
+inline uint64_t decode_varint(const char **data, const char *end) {
+  // If this is a one-byte varint, decode it here.
+  if (end != *data && ((static_cast<uint64_t>(**data) & 0x80U) == 0)) {
+    const auto val = static_cast<uint64_t>(**data);
+    ++(*data);
     return val;
   }
+  // If this varint is more than one byte, defer to complete implementation.
+  return detail::decode_varint_impl(data, end);
+}
 
-  inline uint64_t decode_varint(const char** data, const char* end) {
-    // If this is a one-byte varint, decode it here.
-    if (end != *data && ((static_cast<uint64_t>(**data) & 0x80U) == 0)) {
-      const auto val = static_cast<uint64_t>(**data);
-      ++(*data);
-      return val;
+inline void rotate(int64_t n, int64_t &x, int64_t &y, int64_t rx, int64_t ry) {
+  if (ry == 0) {
+    if (rx == 1) {
+      x = n - 1 - x;
+      y = n - 1 - y;
     }
-    // If this varint is more than one byte, defer to complete implementation.
-    return detail::decode_varint_impl(data, end);
+    int64_t t = x;
+    x = y;
+    y = t;
   }
+}
 
-  inline void rotate(int64_t n, int64_t &x, int64_t &y, int64_t rx, int64_t ry) {
-    if (ry == 0) {
-      if (rx == 1) {
-          x = n-1 - x;
-          y = n-1 - y;
-      }
-      int64_t t = x;
-      x = y;
-      y = t;
-    }
+inline zxy t_on_level(uint8_t z, uint64_t pos) {
+  int64_t n = 1 << z;
+  int64_t rx, ry, s, t = pos;
+  int64_t tx = 0;
+  int64_t ty = 0;
+
+  for (s = 1; s < n; s *= 2) {
+    rx = 1 & (t / 2);
+    ry = 1 & (t ^ rx);
+    rotate(s, tx, ty, rx, ry);
+    tx += s * rx;
+    ty += s * ry;
+    t /= 4;
   }
-
-  inline zxy t_on_level(uint8_t z, uint64_t pos) {
-    int64_t n = 1 << z;
-    int64_t rx, ry, s, t = pos;
-    int64_t tx = 0;
-    int64_t ty = 0;
-
-    for (s=1; s<n; s*=2) {
-      rx = 1 & (t/2);
-      ry = 1 & (t ^ rx);
-      rotate(s, tx, ty, rx, ry);
-      tx += s * rx;
-      ty += s * ry;
-      t /= 4;
-    }
-    return zxy(z,tx,ty);
-  }
-} // end namespace detail
+  return zxy(z, tx, ty);
+}
+}  // end namespace detail
 
 inline int write_varint(std::back_insert_iterator<std::string> data, uint64_t value) {
   int n = 1;
@@ -211,10 +305,10 @@ inline int write_varint(std::back_insert_iterator<std::string> data, uint64_t va
 inline zxy tileid_to_zxy(uint64_t tileid) {
   uint64_t acc = 0;
   uint8_t t_z = 0;
-  while(true) {
+  while (true) {
     uint64_t num_tiles = (1 << t_z) * (1 << t_z);
     if (acc + num_tiles > tileid) {
-        return detail::t_on_level(t_z, tileid - acc);
+      return detail::t_on_level(t_z, tileid - acc);
     }
     acc += num_tiles;
     t_z++;
@@ -225,10 +319,10 @@ inline uint64_t zxy_to_tileid(uint8_t z, uint32_t x, uint32_t y) {
   uint64_t acc = 0;
   for (uint8_t t_z = 0; t_z < z; t_z++) acc += (0x1 << t_z) * (0x1 << t_z);
   int64_t n = 1 << z;
-  int64_t rx, ry, s, d=0;
+  int64_t rx, ry, s, d = 0;
   int64_t tx = x;
   int64_t ty = y;
-  for (s=n/2; s>0; s/=2) {
+  for (s = n / 2; s > 0; s /= 2) {
     rx = (tx & s) > 0;
     ry = (ty & s) > 0;
     d += s * s * ((3 * rx) ^ ry);
@@ -238,7 +332,7 @@ inline uint64_t zxy_to_tileid(uint8_t z, uint32_t x, uint32_t y) {
 }
 
 // returns an uncompressed byte buffer
-inline std::string serialize_directory(const std::vector<entryv3>& entries) {
+inline std::string serialize_directory(const std::vector<entryv3> &entries) {
   std::string data;
 
   write_varint(std::back_inserter(data), entries.size());
@@ -258,10 +352,10 @@ inline std::string serialize_directory(const std::vector<entryv3>& entries) {
   }
 
   for (size_t i = 0; i < entries.size(); i++) {
-    if (i > 0 && entries[i].offset == entries[i-1].offset + entries[i-1].length) {
+    if (i > 0 && entries[i].offset == entries[i - 1].offset + entries[i - 1].length) {
       write_varint(std::back_inserter(data), 0);
     } else {
-      write_varint(std::back_inserter(data), entries[i].offset+1);
+      write_varint(std::back_inserter(data), entries[i].offset + 1);
     }
   }
 
@@ -273,31 +367,31 @@ inline std::vector<entryv3> deserialize_directory(const std::string &decompresse
   const char *t = decompressed.data();
   const char *end = t + decompressed.size();
 
-  uint64_t num_entries = detail::decode_varint(&t,end);
+  uint64_t num_entries = detail::decode_varint(&t, end);
 
   std::vector<entryv3> result;
   result.resize(num_entries);
 
   uint64_t last_id = 0;
   for (size_t i = 0; i < num_entries; i++) {
-    uint64_t tile_id = last_id + detail::decode_varint(&t,end);
+    uint64_t tile_id = last_id + detail::decode_varint(&t, end);
     result[i].tile_id = tile_id;
     last_id = tile_id;
   }
 
   for (size_t i = 0; i < num_entries; i++) {
-    result[i].run_length = detail::decode_varint(&t,end);
+    result[i].run_length = detail::decode_varint(&t, end);
   }
 
   for (size_t i = 0; i < num_entries; i++) {
-    result[i].length = detail::decode_varint(&t,end);
+    result[i].length = detail::decode_varint(&t, end);
   }
 
   for (size_t i = 0; i < num_entries; i++) {
-    uint64_t tmp = detail::decode_varint(&t,end);
+    uint64_t tmp = detail::decode_varint(&t, end);
 
     if (i > 0 && tmp == 0) {
-      result[i].offset = result[i-1].offset + result[i-1].length;
+      result[i].offset = result[i - 1].offset + result[i - 1].length;
     } else {
       result[i].offset = tmp - 1;
     }
@@ -312,5 +406,5 @@ inline std::vector<entryv3> deserialize_directory(const std::string &decompresse
   return result;
 }
 
-}
+}  // namespace pmtiles
 #endif

--- a/pmtiles_file.cpp
+++ b/pmtiles_file.cpp
@@ -1,0 +1,186 @@
+#include <sys/stat.h>
+#include <unistd.h>
+#include "pmtiles_file.hpp"
+#include "write_json.hpp"
+#include "version.hpp"
+
+pmtiles_file *pmtiles_open(const char *filename, char **argv, int force, const char* tmpdir) {
+	pmtiles_file *outfile = new pmtiles_file;
+
+	struct stat st;
+	if (force) {
+		unlink(filename);
+	} else {
+		if (stat(filename, &st) == 0) {
+			fprintf(stderr, "%s: %s: file exists\n", argv[0], filename);
+			exit(EXIT_FAILURE);
+		}
+	}
+	outfile->ostream.open(filename,std::ios::out | std::ios::binary);
+
+	char tmpname[strlen(tmpdir) + strlen("/pmtiles.XXXXXX") + 1];
+	sprintf(tmpname, "%s%s", tmpdir, "/pmtiles.XXXXXX");
+	int tmpfd = mkstemp(tmpname);
+	close(tmpfd);
+
+	outfile->tmptilesname = tmpname;
+	outfile->tilestmp.open(tmpname,std::ios::out | std::ios::binary);
+	outfile->offset = 0;
+	return outfile;
+}
+
+void pmtiles_write_tile(pmtiles_file  *outfile, int z, int tx, int ty, const char *data, int size) {
+	fprintf(stderr, "%d %d %d\n", z, tx, ty);
+	// TODO: add entry to entries
+	outfile->tilestmp.write(data, size);
+	outfile->offset += size;
+}
+
+std::string pmtiles_metadata_json(const char *fname, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline) {
+	std::string buf;
+	json_writer state(&buf);
+	state.json_write_hash();
+	state.nospace = true;
+
+	state.json_write_newline();
+
+	state.json_write_string("name");
+	state.json_write_string(fname);
+	state.json_comma_newline();
+
+	state.json_write_string("description");
+	state.json_write_string(description != NULL ? description : fname);
+	state.json_comma_newline();
+
+	state.json_write_string("version");
+	state.json_write_string("2");
+	state.json_comma_newline();
+
+	state.json_write_string("type");
+	state.json_write_string("overlay");
+	state.json_comma_newline();
+
+	if (attribution != NULL) {
+		state.json_write_string("attribution");
+		state.json_write_string(attribution);
+		state.json_comma_newline();
+	}
+
+	std::string version = program + " " + VERSION;
+	state.json_write_string("generator");
+	state.json_write_string(version);
+	state.json_comma_newline();
+
+	state.json_write_string("generator_options");
+	state.json_write_string(commandline);
+	state.json_comma_newline();
+
+	if (vector) {
+		size_t elements = max_tilestats_values;
+
+		{
+			state.json_write_string("vector_layers");
+			state.json_write_array();
+
+			std::vector<std::string> lnames;
+			for (auto ai = layermap.begin(); ai != layermap.end(); ++ai) {
+				lnames.push_back(ai->first);
+			}
+
+			for (size_t i = 0; i < lnames.size(); i++) {
+				auto fk = layermap.find(lnames[i]);
+				state.json_write_hash();
+
+				state.json_write_string("id");
+				state.json_write_string(lnames[i]);
+
+				state.json_write_string("description");
+				state.json_write_string(fk->second.description);
+
+				state.json_write_string("minzoom");
+				state.json_write_signed(fk->second.minzoom);
+
+				state.json_write_string("maxzoom");
+				state.json_write_signed(fk->second.maxzoom);
+
+				state.json_write_string("fields");
+				state.json_write_hash();
+				state.nospace = true;
+
+				bool first = true;
+				for (auto j = fk->second.file_keys.begin(); j != fk->second.file_keys.end(); ++j) {
+					if (first) {
+						first = false;
+					}
+
+					state.json_write_string(j->first);
+
+					auto f = attribute_descriptions.find(j->first);
+					if (f == attribute_descriptions.end()) {
+						int type = 0;
+						for (auto s : j->second.sample_values) {
+							type |= (1 << s.type);
+						}
+
+						if (type == (1 << mvt_double)) {
+							state.json_write_string("Number");
+						} else if (type == (1 << mvt_bool)) {
+							state.json_write_string("Boolean");
+						} else if (type == (1 << mvt_string)) {
+							state.json_write_string("String");
+						} else {
+							state.json_write_string("Mixed");
+						}
+					} else {
+						state.json_write_string(f->second);
+					}
+				}
+
+				state.nospace = true;
+				state.json_end_hash();
+				state.json_end_hash();
+			}
+
+			state.json_end_array();
+
+			if (do_tilestats && elements > 0) {
+				state.nospace = true;
+				state.json_write_string("tilestats");
+				tilestats(layermap, elements, state);
+			}
+		}
+	}
+
+	state.nospace = true;
+	state.json_end_hash();
+
+	std::string compressed;
+	compress(buf,compressed);
+	return compressed;
+}
+
+void pmtiles_write_metadata(pmtiles_file *outfile, const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline) {
+	// set header fields
+	outfile->json_metadata = pmtiles_metadata_json(fname, attribution, layermap, vector, description, do_tilestats, attribute_descriptions, program, commandline);
+
+	fprintf(stderr, "%d %d %f %f %f %f %f %f\n", minzoom, maxzoom, minlon, minlat, maxlon, maxlat, midlon, midlat);
+}
+
+void pmtiles_finalize(pmtiles_file *outfile) {
+	outfile->tilestmp.close();
+
+	// TODO: serialize sorted directories and set header fields
+
+	std::ifstream tilestmp(outfile->tmptilesname, std::ios::in | std::ios_base::binary);
+
+	outfile->ostream.write(outfile->json_metadata.data(), outfile->json_metadata.size());
+	// TODO: write leaf dirs
+	outfile->ostream << tilestmp.rdbuf();
+
+	tilestmp.close();
+	unlink(outfile->tmptilesname.c_str());
+
+	outfile->ostream.close();
+
+	delete outfile;
+};

--- a/pmtiles_file.hpp
+++ b/pmtiles_file.hpp
@@ -17,6 +17,18 @@ struct pmtiles_file {
 	pmtiles::headerv3 header;
 };
 
+struct pmtiles_zxy_entry {
+	long long z;
+	long long x;
+	long long y;
+	uint64_t offset;
+	uint32_t length;
+
+	pmtiles_zxy_entry(long long _z, long long _x, long long _y, uint64_t _offset, uint32_t _length)
+	    : z(_z), x(_x), y(_y), offset(_offset), length(_length) {
+	}
+};
+
 #include "mbtiles.hpp"
 
 bool pmtiles_has_suffix(const char *filename);
@@ -28,5 +40,7 @@ void pmtiles_write_tile(pmtiles_file *outfile, int z, int tx, int ty, const char
 void pmtiles_write_metadata(pmtiles_file *outfile, const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline);
 
 void pmtiles_finalize(pmtiles_file *outfile);
+
+std::vector<pmtiles_zxy_entry> pmtiles_entries_colmajor(const char *pmtiles_map);
 
 #endif

--- a/pmtiles_file.hpp
+++ b/pmtiles_file.hpp
@@ -7,15 +7,18 @@
 
 struct pmtiles_file {
 	uint64_t offset = 0;
-	std::string tmptilesname;
 	std::ofstream ostream;
-	std::ofstream tilestmp;
+	std::ofstream tmp_ostream;
+	std::string tmp_name;
 	std::string json_metadata;
+	pthread_mutex_t lock;
 };
 
 #include "mbtiles.hpp"
 
-pmtiles_file *pmtiles_open(const char *filename, char **argv, int force, const char *tmpdir);
+bool pmtiles_has_suffix(const char *filename);
+
+pmtiles_file *pmtiles_open(const char *filename, char **argv, int force);
 
 void pmtiles_write_tile(pmtiles_file *outfile, int z, int tx, int ty, const char *data, int size);
 

--- a/pmtiles_file.hpp
+++ b/pmtiles_file.hpp
@@ -1,9 +1,10 @@
-#ifndef PMTILES_HPP
-#define PMTILES_HPP
+#ifndef PMTILES_FILE_HPP
+#define PMTILES_FILE_HPP
 
 #include <vector>
 #include <fstream>
 #include <map>
+#include "pmtiles/pmtiles.hpp"
 
 struct pmtiles_file {
 	uint64_t offset = 0;
@@ -12,6 +13,8 @@ struct pmtiles_file {
 	std::string tmp_name;
 	std::string json_metadata;
 	pthread_mutex_t lock;
+	std::vector<pmtiles::entryv3> entries;
+	pmtiles::headerv3 header;
 };
 
 #include "mbtiles.hpp"

--- a/pmtiles_file.hpp
+++ b/pmtiles_file.hpp
@@ -1,0 +1,26 @@
+#ifndef PMTILES_HPP
+#define PMTILES_HPP
+
+#include <vector>
+#include <fstream>
+#include <map>
+
+struct pmtiles_file {
+	uint64_t offset = 0;
+	std::string tmptilesname;
+	std::ofstream ostream;
+	std::ofstream tilestmp;
+	std::string json_metadata;
+};
+
+#include "mbtiles.hpp"
+
+pmtiles_file *pmtiles_open(const char *filename, char **argv, int force, const char *tmpdir);
+
+void pmtiles_write_tile(pmtiles_file *outfile, int z, int tx, int ty, const char *data, int size);
+
+void pmtiles_write_metadata(pmtiles_file *outfile, const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline);
+
+void pmtiles_finalize(pmtiles_file *outfile);
+
+#endif

--- a/tile.hpp
+++ b/tile.hpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <map>
 #include "mbtiles.hpp"
+#include "pmtiles_file.hpp"
 #include "jsonpull/jsonpull.h"
 
 enum attribute_op {
@@ -63,7 +64,7 @@ struct strategy {
 
 long long write_tile(char **geom, char *metabase, char *stringpool, unsigned *file_bbox, int z, unsigned x, unsigned y, int detail, int min_detail, int basezoom, sqlite3 *outdb, const char *outdir, double droprate, int buffer, const char *fname, FILE **geomfile, int file_minzoom, int file_maxzoom, double todo, char *geomstart, long long along, double gamma, int nlayers, std::atomic<strategy> *strategy);
 
-int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpool, std::atomic<unsigned> *midx, std::atomic<unsigned> *midy, int &maxzoom, int minzoom, sqlite3 *outdb, const char *outdir, int buffer, const char *fname, const char *tmpdir, double gamma, int full_detail, int low_detail, int min_detail, long long *meta_off, long long *pool_off, unsigned *initial_x, unsigned *initial_y, double simplification, double maxzoom_simplification, std::vector<std::map<std::string, layermap_entry> > &layermap, const char *prefilter, const char *postfilter, std::map<std::string, attribute_op> const *attribute_accum, struct json_object *filter, std::vector<strategy> &strategies);
+int traverse_zooms(int *geomfd, off_t *geom_size, char *metabase, char *stringpool, std::atomic<unsigned> *midx, std::atomic<unsigned> *midy, int &maxzoom, int minzoom, sqlite3 *outdb, pmtiles_file *outfile, const char *outdir, int buffer, const char *fname, const char *tmpdir, double gamma, int full_detail, int low_detail, int min_detail, long long *meta_off, long long *pool_off, unsigned *initial_x, unsigned *initial_y, double simplification, double maxzoom_simplification, std::vector<std::map<std::string, layermap_entry> > &layermap, const char *prefilter, const char *postfilter, std::map<std::string, attribute_op> const *attribute_accum, struct json_object *filter, std::vector<strategy> &strategies);
 
 int manage_gap(unsigned long long index, unsigned long long *previndex, double scale, double gamma, double *gap);
 


### PR DESCRIPTION
Implement hooks in code for writing PMTiles v3 output directly. 

~~Opening this as a draft although it's not quite ready to merge yet.~~

~~It makes sense IMO to just implement this within Tippecanoe instead of as a separate dependency to take advantage of the existing functionality for varint encoding via protozero and JSON serialization. What's currently missing is:~~

* support for leaf directories and directories > 16 kB (small archives only)
* sorted/clustered archives, which should be the default and will require a final sorting step over the tile data tempfile
* deduplication. currently this just assumes every tile is unique which will be mostly true in many tippecanoe use cases; to do this we will need to add some hash function: low complexity would be fnv, or vendor in a library like xxhash. 

More comments inline