### PR TITLE
Allow passing a file with a list of input files to tile-join in response to issue 69

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,15 @@ join-test: tile-join
 	./tippecanoe-decode -x generator tests/join-population/concat.mbtiles > tests/join-population/concat.mbtiles.json.check
 	cmp tests/join-population/concat.mbtiles.json.check tests/join-population/concat.mbtiles.json
 	rm tests/join-population/concat.mbtiles.json.check tests/join-population/concat.mbtiles tests/join-population/macarthur.mbtiles
+	# Test reading list of input files from file
+	./tippecanoe -q -f -Z5 -z10 -o tests/readfile/macarthur.mbtiles -l macarthur1 tests/join-population/macarthur.json
+	./tippecanoe -q -f -Z5 -z10 -o tests/readfile/macarthur2.mbtiles -l macarthur2 tests/join-population/macarthur2.json
+	./tile-join -q -R macarthur1:one --rename-layer=macarthur2:two -f -o tests/readfile/renamed.mbtiles tests/readfile/macarthur.mbtiles tests/readfile/macarthur2.mbtiles
+	./tippecanoe-decode -x generator -x generator_options tests/readfile/renamed.mbtiles > tests/readfile/renamed.mbtiles.json.check
+	./tile-join -q -R macarthur1:one --rename-layer=macarthur2:two -f -r tests/readfile/readfile.list -o tests/readfile/readfile.mbtiles
+	./tippecanoe-decode -x generator -x generator_options tests/readfile/readfile.mbtiles > tests/readfile/readfile.mbtiles.json.check
+	cmp tests/readfile/renamed.mbtiles.json.check tests/readfile/readfile.mbtiles.json.check
+	rm tests/readfile/renamed.mbtiles.json.check tests/readfile/readfile.mbtiles.json.check  tests/readfile/readfile.mbtiles tests/readfile/renamed.mbtiles
 	#`
 	# Make sure empty tilesets work
 	#

--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ The options are:
  * `-o` *out.mbtiles*, *out.pmtiles* or `--output=`*out.mbtiles*: Write the new tiles to the specified .mbtiles file.
  * `-e` *directory* or `--output-to-directory=`*directory*: Write the new tiles to the specified directory instead of to an mbtiles file.
  * `-f` or `--force`: Remove *out.mbtiles* if it already exists.
+ * `-r` or `--read-from`: list of input mbtiles to read from.
 
 ### Tileset description and attribution
 

--- a/tests/readfile/readfile.list
+++ b/tests/readfile/readfile.list
@@ -1,0 +1,2 @@
+tests/readfile/macarthur.mbtiles
+tests/readfile/macarthur2.mbtiles

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -411,7 +411,6 @@ struct reader {
 struct reader *begin_reading(char *fname) {
 	struct reader *r = new reader;
 	r->name = fname;
-
 	struct stat st;
 	if (stat(fname, &st) == 0 && (st.st_mode & S_IFDIR) != 0) {
 		r->db = NULL;
@@ -959,7 +958,7 @@ void decode(struct reader *readers, std::map<std::string, layermap_entry> &layer
 }
 
 void usage(char **argv) {
-	fprintf(stderr, "Usage: %s [-f] [-i] [-pk] [-pC] [-c joins.csv] [-X] [-x exclude ...] -o new.mbtiles source.mbtiles ...\n", argv[0]);
+	fprintf(stderr, "Usage: %s [-f] [-i] [-pk] [-pC] [-c joins.csv] [-X] [-x exclude ...] [-r inputfile.txt ] -o new.mbtiles source.mbtiles ...\n", argv[0]);
 	exit(EXIT_ARGS);
 }
 
@@ -970,7 +969,10 @@ int main(int argc, char **argv) {
 	char *csv = NULL;
 	int force = 0;
 	int ifmatched = 0;
+	int filearg = 0;
 	json_object *filter = NULL;
+
+	struct reader *readers = NULL;
 
 	CPUS = sysconf(_SC_NPROCESSORS_ONLN);
 
@@ -1011,6 +1013,7 @@ int main(int argc, char **argv) {
 		{"feature-filter-file", required_argument, 0, 'J'},
 		{"feature-filter", required_argument, 0, 'j'},
 		{"rename-layer", required_argument, 0, 'R'},
+		{"read-from", required_argument, 0, 'r'},
 
 		{"no-tile-size-limit", no_argument, &pk, 1},
 		{"no-tile-compression", no_argument, &pC, 1},
@@ -1143,6 +1146,29 @@ int main(int argc, char **argv) {
 			break;
 		}
 
+		case 'r': {
+			std::fstream read_file;
+			read_file.open(std::string(optarg), std::ios::in);
+			if (read_file.is_open()) {
+				std::string sa;
+				filearg = 1;
+				while (getline(read_file, sa)) {
+					char* c = const_cast<char*>(sa.c_str());
+					reader *r = begin_reading(c);
+					struct reader **rr;
+					for (rr = &readers; *rr != NULL; rr = &((*rr)->next)) {
+						if (*r < **rr) {
+							break;
+						}
+					}
+					r->next = *rr;
+					*rr = r;
+				}
+				read_file.close();
+			}
+
+		}
+
 		case 'q':
 			quiet = true;
 			break;
@@ -1211,20 +1237,21 @@ int main(int argc, char **argv) {
 	std::string description;
 	std::string name;
 
-	struct reader *readers = NULL;
 
-	for (i = optind; i < argc; i++) {
-		reader *r = begin_reading(argv[i]);
-		struct reader **rr;
+	if (filearg == 0) {
+		for (i = optind; i < argc; i++) {
+			reader *r = begin_reading(argv[i]);
+			struct reader **rr;
 
-		for (rr = &readers; *rr != NULL; rr = &((*rr)->next)) {
-			if (*r < **rr) {
-				break;
+			for (rr = &readers; *rr != NULL; rr = &((*rr)->next)) {
+				if (*r < **rr) {
+					break;
+				}
 			}
-		}
 
-		r->next = *rr;
-		*rr = r;
+			r->next = *rr;
+			*rr = r;
+		}
 	}
 
 	std::map<std::string, std::string> attribute_descriptions;

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -1193,7 +1193,7 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	if (argc - optind < 1) {
+	if ((argc - optind < 1) && (filearg == 0)) {
 		usage(argv);
 	}
 


### PR DESCRIPTION
In response to #69 add a -r to allow passing a file containing the list of files to use as source inputs to join