### PR TITLE
Calculate an antimeridian-adjusted bounding box in tileset metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+# 2.24.0
+
 * Add --cluster-maxzoom option to limit zoom levels that receive clustering
 * Add `point_count_abbreviated` attribute to clustered features, for consistency with supercluster
 * Makefile changes to support FreeBSD
 * Add -r option to tile-join to provide a file containing a list of input files
+* Add antimeridian_adjusted_bounds field to tileset metadata
 
 ## 2.23.0
 

--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -310,6 +310,7 @@ void dir_write_metadata(const char *outdir, const metadata &m) {
 		out(state, "maxzoom", std::to_string(m.maxzoom));
 		out(state, "center", std::to_string(m.center_lon) + "," + std::to_string(m.center_lat) + "," + std::to_string(m.center_z));
 		out(state, "bounds", std::to_string(m.minlon) + "," + std::to_string(m.minlat) + "," + std::to_string(m.maxlon) + "," + std::to_string(m.maxlat));
+		out(state, "antimeridian_adjusted_bounds", std::to_string(m.minlon2) + "," + std::to_string(m.minlat2) + "," + std::to_string(m.maxlon2) + "," + std::to_string(m.maxlat2));
 		out(state, "type", m.type);
 		if (m.attribution.size() > 0) {
 			out(state, "attribution", m.attribution);

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -530,6 +530,15 @@ void mbtiles_write_metadata(sqlite3 *db, const metadata &m, bool forcetable) {
 	}
 	sqlite3_free(sql);
 
+	sql = sqlite3_mprintf("INSERT INTO metadata (name, value) VALUES ('antimeridian_adjusted_bounds', '%f,%f,%f,%f');", m.minlon2, m.minlat2, m.maxlon2, m.maxlat2);
+	if (sqlite3_exec(db, sql, NULL, NULL, &err) != SQLITE_OK) {
+		fprintf(stderr, "set bounds: %s\n", err);
+		if (!forcetable) {
+			exit(EXIT_SQLITE);
+		}
+	}
+	sqlite3_free(sql);
+
 	sql = sqlite3_mprintf("INSERT INTO metadata (name, value) VALUES ('type', %Q);", m.type.c_str());
 	if (sqlite3_exec(db, sql, NULL, NULL, &err) != SQLITE_OK) {
 		fprintf(stderr, "set type: %s\n", err);
@@ -629,7 +638,7 @@ void mbtiles_write_metadata(sqlite3 *db, const metadata &m, bool forcetable) {
 	}
 }
 
-metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies) {
+metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double minlat2, double minlon2, double maxlat2, double maxlon2, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies) {
 	metadata m;
 
 	m.name = fname;
@@ -645,6 +654,11 @@ metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minla
 	m.minlon = minlon;
 	m.maxlat = maxlat;
 	m.maxlon = maxlon;
+
+	m.minlat2 = minlat2;
+	m.minlon2 = minlon2;
+	m.maxlat2 = maxlat2;
+	m.maxlon2 = maxlon2;
 
 	m.center_lat = midlat;
 	m.center_lon = midlon;

--- a/mbtiles.hpp
+++ b/mbtiles.hpp
@@ -52,6 +52,7 @@ struct metadata {
 	int maxzoom;
 
 	double minlat, minlon, maxlat, maxlon;
+	double minlat2, minlon2, maxlat2, maxlon2;  // antimeridian-aware
 
 	double center_lon, center_lat;
 	int center_z;
@@ -74,7 +75,7 @@ sqlite3 *mbtiles_open(char *dbname, char **argv, int forcetable);
 void mbtiles_write_tile(sqlite3 *outdb, int z, int tx, int ty, const char *data, int size);
 void mbtiles_erase_zoom(sqlite3 *outdb, int z);
 
-metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies);
+metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double minlat2, double minlon2, double maxlat2, double maxlon2, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies);
 void mbtiles_write_metadata(sqlite3 *db, const metadata &m, bool forcetable);
 
 void mbtiles_close(sqlite3 *outdb, const char *pgm);

--- a/pmtiles_file.cpp
+++ b/pmtiles_file.cpp
@@ -105,6 +105,9 @@ std::string metadata_to_pmtiles_json(metadata m) {
 	out(state, "generator", m.generator);
 	out(state, "generator_options", m.generator_options);
 
+	std::string bounds2 = std::to_string(m.minlon2) + "," + std::to_string(m.minlat2) + "," + std::to_string(m.maxlon2) + "," + std::to_string(m.maxlat2);
+	out(state, "antimeridian_adjusted_bounds", bounds2);
+
 	if (m.vector_layers_json.size() > 0) {
 		state.json_comma_newline();
 		state.json_write_string("vector_layers");

--- a/serial.cpp
+++ b/serial.cpp
@@ -402,6 +402,32 @@ int serialize_feature(struct serialization_state *sst, serial_feature &sf) {
 	sf.bbox[2] = LLONG_MIN;
 	sf.bbox[3] = LLONG_MIN;
 
+	for (size_t i = 0; i < sf.geometry.size(); i++) {
+		if (sf.geometry[i].op == VT_MOVETO || sf.geometry[i].op == VT_LINETO) {
+			// standard -180 to 180 world plane
+
+			long long x = sf.geometry[i].x & 0xFFFFFFFF;
+			long long y = sf.geometry[i].y & 0xFFFFFFFF;
+
+			r->file_bbox1[0] = std::min(r->file_bbox1[0], x);
+			r->file_bbox1[1] = std::min(r->file_bbox1[1], y);
+			r->file_bbox1[2] = std::max(r->file_bbox1[2], x);
+			r->file_bbox1[3] = std::max(r->file_bbox1[3], y);
+
+			// printf("%llx,%llx  %llx,%llx %llx,%llx\n", x, y, r->file_bbox1[0], r->file_bbox1[1], r->file_bbox1[2], r->file_bbox1[3]);
+
+			// shift the western hemisphere 360 degrees to the east
+			if (x < 0x80000000) {  // prime meridian
+				x += 0x100000000;
+			}
+
+			r->file_bbox2[0] = std::min(r->file_bbox2[0], x);
+			r->file_bbox2[1] = std::min(r->file_bbox2[1], y);
+			r->file_bbox2[2] = std::max(r->file_bbox2[2], x);
+			r->file_bbox2[3] = std::max(r->file_bbox2[3], y);
+		}
+	}
+
 	// try to remind myself that the geometry in this function is in SCALED COORDINATES
 	drawvec scaled_geometry = sf.geometry;
 	sf.geometry.clear();

--- a/serial.cpp
+++ b/serial.cpp
@@ -404,27 +404,29 @@ int serialize_feature(struct serialization_state *sst, serial_feature &sf) {
 
 	for (size_t i = 0; i < sf.geometry.size(); i++) {
 		if (sf.geometry[i].op == VT_MOVETO || sf.geometry[i].op == VT_LINETO) {
-			// standard -180 to 180 world plane
+			if (sf.geometry[i].y > 0 && sf.geometry[i].y < 0xFFFFFFFF) {
+				// standard -180 to 180 world plane
 
-			long long x = sf.geometry[i].x & 0xFFFFFFFF;
-			long long y = sf.geometry[i].y & 0xFFFFFFFF;
+				long long x = sf.geometry[i].x & 0xFFFFFFFF;
+				long long y = sf.geometry[i].y & 0xFFFFFFFF;
 
-			r->file_bbox1[0] = std::min(r->file_bbox1[0], x);
-			r->file_bbox1[1] = std::min(r->file_bbox1[1], y);
-			r->file_bbox1[2] = std::max(r->file_bbox1[2], x);
-			r->file_bbox1[3] = std::max(r->file_bbox1[3], y);
+				r->file_bbox1[0] = std::min(r->file_bbox1[0], x);
+				r->file_bbox1[1] = std::min(r->file_bbox1[1], y);
+				r->file_bbox1[2] = std::max(r->file_bbox1[2], x);
+				r->file_bbox1[3] = std::max(r->file_bbox1[3], y);
 
-			// printf("%llx,%llx  %llx,%llx %llx,%llx\n", x, y, r->file_bbox1[0], r->file_bbox1[1], r->file_bbox1[2], r->file_bbox1[3]);
+				// printf("%llx,%llx  %llx,%llx %llx,%llx  ", x, y, r->file_bbox1[0], r->file_bbox1[1], r->file_bbox1[2], r->file_bbox1[3]);
 
-			// shift the western hemisphere 360 degrees to the east
-			if (x < 0x80000000) {  // prime meridian
-				x += 0x100000000;
+				// shift the western hemisphere 360 degrees to the east
+				if (x < 0x80000000) {  // prime meridian
+					x += 0x100000000;
+				}
+
+				r->file_bbox2[0] = std::min(r->file_bbox2[0], x);
+				r->file_bbox2[1] = std::min(r->file_bbox2[1], y);
+				r->file_bbox2[2] = std::max(r->file_bbox2[2], x);
+				r->file_bbox2[3] = std::max(r->file_bbox2[3], y);
 			}
-
-			r->file_bbox2[0] = std::min(r->file_bbox2[0], x);
-			r->file_bbox2[1] = std::min(r->file_bbox2[1], y);
-			r->file_bbox2[2] = std::max(r->file_bbox2[2], x);
-			r->file_bbox2[3] = std::max(r->file_bbox2[3], y);
 		}
 	}
 

--- a/serial.hpp
+++ b/serial.hpp
@@ -88,6 +88,9 @@ struct reader {
 
 	long long file_bbox[4] = {0, 0, 0, 0};
 
+	long long file_bbox1[4] = {0xFFFFFFFF, 0xFFFFFFFF, 0, 0};  // standard -180 to 180 world plane
+	long long file_bbox2[4] = {0x1FFFFFFFF, 0xFFFFFFFF, 0x100000000, 0};  // 0 to 360 world plane
+
 	struct stat geomst {};
 
 	char *geom_map = NULL;

--- a/tests/accumulate/out/-z3_-Ethesum@sum_-Etheproduct@product_-Ethemax@max_-Ethemin@min_-Ethemean@mean_-Etheconcat@concat_-Ethecomma@comma_-r1_-K100.json
+++ b/tests/accumulate/out/-z3_-Ethesum@sum_-Etheproduct@product_-Ethemax@max_-Ethemin@min_-Ethemean@mean_-Etheconcat@concat_-Ethecomma@comma_-r1_-K100.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "112.500000,20.489949,3",
 "description": "tests/accumulate/out/-z3_-Ethesum@sum_-Etheproduct@product_-Ethemax@max_-Ethemin@min_-Ethemean@mean_-Etheconcat@concat_-Ethecomma@comma_-r1_-K100.json.check.mbtiles",

--- a/tests/accumulate/out/-z5_-Ethesum@sum_-Etheproduct@product_-Ethemax@max_-Ethemin@min_-Ethemean@mean_-Etheconcat@concat_-Ethecomma@comma.json
+++ b/tests/accumulate/out/-z5_-Ethesum@sum_-Etheproduct@product_-Ethemax@max_-Ethemin@min_-Ethemean@mean_-Etheconcat@concat_-Ethecomma@comma.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "-174.375000,-52.349536,5",
 "description": "tests/accumulate/out/-z5_-Ethesum@sum_-Etheproduct@product_-Ethemax@max_-Ethemin@min_-Ethemean@mean_-Etheconcat@concat_-Ethecomma@comma.json.check.mbtiles",

--- a/tests/allow-existing/both.mbtiles.json
+++ b/tests/allow-existing/both.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.373782,37.454389,-121.469214,37.905824",
 "bounds": "-122.373782,37.454389,-121.469214,37.905824",
 "center": "-121.992188,37.454389,9",
 "description": "tests/allow-existing/both.mbtiles",

--- a/tests/attribute-type/out/-z0_-Tinttype@int_-Tfloattype@float_-Tbooltype@bool_-Tstringtype@string.json
+++ b/tests/attribute-type/out/-z0_-Tinttype@int_-Tfloattype@float_-Tbooltype@bool_-Tstringtype@string.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.000000,0.000000",
 "bounds": "0.000000,0.000000,0.000000,0.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/attribute-type/out/-z0_-Tinttype@int_-Tfloattype@float_-Tbooltype@bool_-Tstringtype@string.json.check.mbtiles",

--- a/tests/attribute-type/out/-z0_-pN.json
+++ b/tests/attribute-type/out/-z0_-pN.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.000000,0.000000",
 "bounds": "0.000000,0.000000,0.000000,0.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/attribute-type/out/-z0_-pN.json.check.mbtiles",

--- a/tests/border/out/-z1_--detect-shared-borders.json
+++ b/tests/border/out/-z1_--detect-shared-borders.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "13.365261,39.637013,23.009582,46.863962",
 "bounds": "13.365261,39.637013,23.009582,46.863962",
 "center": "23.009582,42.525564,1",
 "description": "tests/border/out/-z1_--detect-shared-borders.json.check.mbtiles",

--- a/tests/coalesce-id/out/-z1_--coalesce_--reorder.json
+++ b/tests/coalesce-id/out/-z1_--coalesce_--reorder.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023803,-85.040752,359.950215,85.002220",
+"antimeridian_adjusted_bounds": "0.023803,-85.040752,359.950215,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "90.000000,42.525564,1",
 "description": "tests/coalesce-id/out/-z1_--coalesce_--reorder.json.check.mbtiles",

--- a/tests/coalesce-id/out/-z1_--coalesce_--reorder.json
+++ b/tests/coalesce-id/out/-z1_--coalesce_--reorder.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023803,-85.040752,359.950215,85.002220",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "90.000000,42.525564,1",
 "description": "tests/coalesce-id/out/-z1_--coalesce_--reorder.json.check.mbtiles",

--- a/tests/coalesce-tract/out/-P_--coalesce_--reorder_-z11_-Z11_-y_STATEFP10_-y_COUNTYFP10_-l_merged.json
+++ b/tests/coalesce-tract/out/-P_--coalesce_--reorder_-z11_-Z11_-y_STATEFP10_-y_COUNTYFP10_-l_merged.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-123.173825,37.454389,-121.469214,37.929824",
 "bounds": "-123.173825,37.454389,-121.469214,37.929824",
 "center": "-122.255859,37.788049,11",
 "description": "tests/coalesce-tract/out/-P_--coalesce_--reorder_-z11_-Z11_-y_STATEFP10_-y_COUNTYFP10_-l_merged.json.check.mbtiles",

--- a/tests/csv/out-null.mbtiles.json
+++ b/tests/csv/out-null.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220565,-41.299988,179.216647,64.150024",
 "bounds": "-180.000000,-41.299988,180.000000,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/csv/out-null.mbtiles",

--- a/tests/csv/out.mbtiles.json
+++ b/tests/csv/out.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220565,-41.299988,179.216647,64.150024",
 "bounds": "-180.000000,-41.299988,180.000000,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/csv/out.mbtiles",

--- a/tests/curve/out/-z2.json
+++ b/tests/curve/out/-z2.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "90.000000,-82.000000,332.000000,83.000000",
 "bounds": "-139.000000,-82.000000,170.000000,83.000000",
 "center": "-135.000000,75.782195,2",
 "description": "tests/curve/out/-z2.json.check.mbtiles",

--- a/tests/curve/out/-z2_--no-clipping.json
+++ b/tests/curve/out/-z2_--no-clipping.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "90.000000,-82.000000,332.000000,83.000000",
 "bounds": "-139.000000,-82.000000,170.000000,83.000000",
 "center": "-135.000000,75.782195,2",
 "description": "tests/curve/out/-z2_--no-clipping.json.check.mbtiles",

--- a/tests/curve/out/-z2_--no-duplication.json
+++ b/tests/curve/out/-z2_--no-duplication.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "90.000000,-82.000000,332.000000,83.000000",
 "bounds": "-139.000000,-82.000000,170.000000,83.000000",
 "center": "45.000000,33.256630,2",
 "description": "tests/curve/out/-z2_--no-duplication.json.check.mbtiles",

--- a/tests/dateline/out/-z5.json
+++ b/tests/dateline/out/-z5.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-180.000000,0.000000,177.539063,68.269386",
 "bounds": "-180.000000,0.000000,180.000000,68.269386",
 "center": "-174.375000,16.560724,5",
 "description": "tests/dateline/out/-z5.json.check.mbtiles",

--- a/tests/dateline/out/-z5_-b0.json
+++ b/tests/dateline/out/-z5_-b0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-180.000000,0.000000,177.539063,68.269386",
 "bounds": "-180.000000,0.000000,180.000000,68.269386",
 "center": "174.375000,44.951199,5",
 "description": "tests/dateline/out/-z5_-b0.json.check.mbtiles",

--- a/tests/empty-linestring/out/-ac.json
+++ b/tests/empty-linestring/out/-ac.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.822234,37.723073,-122.249782,38.090533",
 "bounds": "-122.822234,37.723073,-122.249782,38.090533",
 "center": "-122.249782,37.796763,14",
 "description": "tests/empty-linestring/out/-ac.json.check.mbtiles",

--- a/tests/epsg-3857/out/-yNAME_-z5_-sEPSG@3857.json
+++ b/tests/epsg-3857/out/-yNAME_-z5_-sEPSG@3857.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220565,-41.299974,179.216647,64.150024",
 "bounds": "-175.220565,-41.299974,179.216647,64.150024",
 "center": "16.875000,44.951199,5",
 "description": "tests/epsg-3857/out/-yNAME_-z5_-sEPSG@3857.json.check.mbtiles",

--- a/tests/feature-filter/out/-z0_-Jtests%feature-filter%filter.json
+++ b/tests/feature-filter/out/-z0_-Jtests%feature-filter%filter.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-101.000000,0.000000,1.000000,1.000000",
 "bounds": "-101.000000,0.000000,1.000000,1.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/feature-filter/out/-z0_-Jtests%feature-filter%filter.json.check.mbtiles",

--- a/tests/feature-filter/out/filtered.json.standard
+++ b/tests/feature-filter/out/filtered.json.standard
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-180.000000,-85.051129,180.000000,85.051129",
 "bounds": "-180.000000,-85.051129,180.000000,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/feature-filter/out/all.mbtiles",

--- a/tests/feature-filter/out/places-filter.mbtiles.json.standard
+++ b/tests/feature-filter/out/places-filter.mbtiles.json.standard
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.781250,-42.032974,180.000000,64.168107",
 "bounds": "-175.781250,-42.032974,180.000000,64.168107",
 "center": "-62.578125,17.307462,8",
 "description": "tests/feature-filter/out/places.mbtiles",

--- a/tests/geometry/out/-z3.json
+++ b/tests/geometry/out/-z3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.000000,-23.563987,102.000000,59.900000",
 "bounds": "-122.000000,-23.563987,102.000000,59.900000",
 "center": "22.500000,20.489949,3",
 "description": "tests/geometry/out/-z3.json.check.mbtiles",

--- a/tests/grid-aligned/out/-z11_-D7_--grid-low-zooms.json
+++ b/tests/grid-aligned/out/-z11_-D7_--grid-low-zooms.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.021973,-0.065918,0.065918,-0.021973",
 "bounds": "0.021973,-0.065918,0.065918,-0.021973",
 "center": "0.065918,-0.065918,11",
 "description": "tests/grid-aligned/out/-z11_-D7_--grid-low-zooms.json.check.mbtiles",

--- a/tests/grid-unaligned/out/-z11_-D7_--grid-low-zooms.json
+++ b/tests/grid-unaligned/out/-z11_-D7_--grid-low-zooms.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.084070,0.057600",
 "bounds": "0.000000,0.000000,0.084070,0.057600",
 "center": "0.084070,0.057600,11",
 "description": "tests/grid-unaligned/out/-z11_-D7_--grid-low-zooms.json.check.mbtiles",

--- a/tests/high-longitude/out/-z1.json
+++ b/tests/high-longitude/out/-z1.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-156.000000,30.000000,-106.000000,35.000000",
 "bounds": "-180.000000,30.000000,180.000000,35.000000",
 "center": "-90.000000,35.000000,1",
 "description": "tests/high-longitude/out/-z1.json.check.mbtiles",

--- a/tests/highzoom/out/-z30.json
+++ b/tests/highzoom/out/-z30.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.000000,37.000000,0.000000,51.500000",
 "bounds": "-122.000000,37.000000,0.000000,51.500000",
 "center": "-122.000000,37.000008,24",
 "description": "tests/highzoom/out/-z30.json.check.mbtiles",

--- a/tests/id/out/-Z11.json
+++ b/tests/id/out/-Z11.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.294563,37.695450,-122.104420,37.833010",
 "bounds": "-122.294563,37.695450,-122.104420,37.833010",
 "center": "-122.156982,37.762029,14",
 "description": "tests/id/out/-Z11.json.check.mbtiles",

--- a/tests/islands/out/-d7_-z7_-pt_-pp.json
+++ b/tests/islands/out/-d7_-z7_-pt_-pp.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "138.063812,-10.009860,209.793590,9.775580",
 "bounds": "-174.543405,-10.009860,174.245778,9.775580",
 "center": "139.218750,9.775580,7",
 "description": "tests/islands/out/-d7_-z7_-pt_-pp.json.check.mbtiles",

--- a/tests/join-population/concat.mbtiles.json
+++ b/tests/join-population/concat.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-180.000000,-85.051129,180.000000,85.051129",
 "bounds": "-180.000000,-85.051129,180.000000,85.051129",
 "center": "-122.104097,37.695438,0",
 "description": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",

--- a/tests/join-population/empty.out.json
+++ b/tests/join-population/empty.out.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,-39.906185,0.000000,-39.906185",
 "bounds": "-180.000000,-85.051129,180.000000,-85.051129",
 "center": "0.000000,-85.051129,0",
 "format": "pbf",

--- a/tests/join-population/empty.out.json
+++ b/tests/join-population/empty.out.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.000000,-39.906185,0.000000,-39.906185",
+"antimeridian_adjusted_bounds": "180.000000,85.051129,-180.000000,-85.051129",
 "bounds": "-180.000000,-85.051129,180.000000,-85.051129",
 "center": "0.000000,-85.051129,0",
 "format": "pbf",

--- a/tests/join-population/joined-i.mbtiles.json
+++ b/tests/join-population/joined-i.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/joined-no-tile-stats.mbtiles.json
+++ b/tests/join-population/joined-no-tile-stats.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/joined-null.mbtiles.json
+++ b/tests/join-population/joined-null.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/joined-tile-stats-attributes-limit.mbtiles.json
+++ b/tests/join-population/joined-tile-stats-attributes-limit.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/joined-tile-stats-sample-values-limit.mbtiles.json
+++ b/tests/join-population/joined-tile-stats-sample-values-limit.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/joined-tile-stats-values-limit.mbtiles.json
+++ b/tests/join-population/joined-tile-stats-values-limit.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/joined.mbtiles.json
+++ b/tests/join-population/joined.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "bounds": "-122.343750,37.857507,-122.255859,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/just-macarthur.mbtiles.json
+++ b/tests/join-population/just-macarthur.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "237.656250,37.857507,237.744141,37.926868",
 "attribution": "macarthur's attribution",
 "bounds": "-122.343750,37.695438,-122.104097,37.926868",
 "center": "-122.299805,37.892187,12",

--- a/tests/join-population/macarthur-6-9-exclude.mbtiles.json
+++ b/tests/join-population/macarthur-6-9-exclude.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "center": "-122.167969,37.833010,9",
 "description": "tests/join-population/macarthur.mbtiles",

--- a/tests/join-population/macarthur-6-9.mbtiles.json
+++ b/tests/join-population/macarthur-6-9.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "center": "-122.167969,37.833010,9",
 "description": "tests/join-population/macarthur.mbtiles",

--- a/tests/join-population/merged-folder.mbtiles.json
+++ b/tests/join-population/merged-folder.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "237.656250,37.857507,237.744141,37.926868",
 "bounds": "-122.343750,37.695438,-122.104097,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420-folder",

--- a/tests/join-population/merged.mbtiles.json
+++ b/tests/join-population/merged.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "237.656250,37.857507,237.744141,37.926868",
 "bounds": "-122.343750,37.695438,-122.104097,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/no-macarthur.mbtiles.json
+++ b/tests/join-population/no-macarthur.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "237.656250,37.857507,237.744141,37.926868",
 "bounds": "-122.343750,37.695438,-122.104097,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/raw-merged-folder.json
+++ b/tests/join-population/raw-merged-folder.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "237.656250,37.857507,237.744141,37.926868",
 "bounds": "-122.343750,37.695438,-122.104097,37.926868",
 "center": "-122.299805,37.892187,12",
 "description": "tests/join-population/tabblock_06001420.mbtiles",

--- a/tests/join-population/renamed.mbtiles.json
+++ b/tests/join-population/renamed.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "center": "-122.167969,37.828608,10",
 "description": "tests/join-population/macarthur2.mbtiles",

--- a/tests/join-population/windows.mbtiles.json
+++ b/tests/join-population/windows.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "bounds": "-122.343750,37.439974,-121.992188,37.996163",
 "center": "-122.167969,37.833010,10",
 "description": "tests/join-population/macarthur.mbtiles",

--- a/tests/knox/out/-zg.json
+++ b/tests/knox/out/-zg.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-87.564090,38.490831,-87.251603,38.902199",
 "bounds": "-87.564090,38.490831,-87.251603,38.902199",
 "center": "-87.363281,38.685378,10",
 "description": "tests/knox/out/-zg.json.check.mbtiles",

--- a/tests/knox/out/-zg_-P.json
+++ b/tests/knox/out/-zg_-P.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-87.564090,38.490831,-87.251603,38.902199",
 "bounds": "-87.564090,38.490831,-87.251603,38.902199",
 "center": "-87.363281,38.685378,10",
 "description": "tests/knox/out/-zg_-P.json.check.mbtiles",

--- a/tests/layer-json/out.mbtiles.json
+++ b/tests/layer-json/out.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/layer-json/out.mbtiles",

--- a/tests/longattr/out/-z0.json
+++ b/tests/longattr/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.000000,0.000000",
 "bounds": "0.000000,0.000000,0.000000,0.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/longattr/out/-z0.json.check.mbtiles",

--- a/tests/longjson/out/-z0.json
+++ b/tests/longjson/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.000000,0.000000",
 "bounds": "0.000000,0.000000,0.000000,0.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/longjson/out/-z0.json.check.mbtiles",

--- a/tests/longlayer/out/-z0.json
+++ b/tests/longlayer/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.000000,0.000000",
 "bounds": "0.000000,0.000000,0.000000,0.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/longlayer/out/-z0.json.check.mbtiles",

--- a/tests/loop/out/-z0_-O200_--cluster-densest-as-needed.json
+++ b/tests/loop/out/-z0_-O200_--cluster-densest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,1.000000,1.000000",
 "bounds": "1.000000,1.000000,1.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/loop/out/-z0_-O200_--cluster-densest-as-needed.json.check.mbtiles",

--- a/tests/loop/out/-z0_-O200_--drop-densest-as-needed.json
+++ b/tests/loop/out/-z0_-O200_--drop-densest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,1.000000,1.000000",
 "bounds": "1.000000,1.000000,1.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/loop/out/-z0_-O200_--drop-densest-as-needed.json.check.mbtiles",

--- a/tests/loop/out/-z0_-O200_--drop-fraction-as-needed.json
+++ b/tests/loop/out/-z0_-O200_--drop-fraction-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,1.000000,1.000000",
 "bounds": "1.000000,1.000000,1.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/loop/out/-z0_-O200_--drop-fraction-as-needed.json.check.mbtiles",

--- a/tests/minzoom/out/-z6.json
+++ b/tests/minzoom/out/-z6.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,6.000000,6.000000",
 "bounds": "0.000000,0.000000,6.000000,6.000000",
 "center": "6.000000,6.000000,6",
 "description": "tests/minzoom/out/-z6.json.check.mbtiles",

--- a/tests/multilayer/out/-ltogether_-z3.json
+++ b/tests/multilayer/out/-ltogether_-z3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,25.789556,-70.645734,49.005639",
 "bounds": "-124.213807,25.789556,-70.645734,49.005639",
 "center": "-70.645734,25.789556,3",
 "description": "tests/multilayer/out/-ltogether_-z3.json.check.mbtiles",

--- a/tests/multilayer/out/-nseparate_-z3.json
+++ b/tests/multilayer/out/-nseparate_-z3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,25.789556,-70.645734,49.005639",
 "bounds": "-124.213807,25.789556,-70.645734,49.005639",
 "center": "-70.645734,25.789556,3",
 "description": "separate",

--- a/tests/multilinestring/out/-z1.json
+++ b/tests/multilinestring/out/-z1.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-34.101500,-16.299000,33.046000,70.728000",
 "bounds": "-34.101500,-16.299000,33.046000,70.728000",
 "center": "-34.101500,42.525564,1",
 "description": "tests/multilinestring/out/-z1.json.check.mbtiles",

--- a/tests/muni/decode/multi.mbtiles.fraction.json
+++ b/tests/muni/decode/multi.mbtiles.fraction.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/decode/multi.mbtiles",

--- a/tests/muni/decode/multi.mbtiles.integer.json
+++ b/tests/muni/decode/multi.mbtiles.integer.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/decode/multi.mbtiles",

--- a/tests/muni/decode/multi.mbtiles.json
+++ b/tests/muni/decode/multi.mbtiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/decode/multi.mbtiles",

--- a/tests/muni/out/-Z11_-z11.json
+++ b/tests/muni/out/-Z11_-z11.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/out/-Z11_-z11.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z11_--calculate-feature-density.json
+++ b/tests/muni/out/-Z11_-z11_--calculate-feature-density.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/out/-Z11_-z11_--calculate-feature-density.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z11_--hilbert.json
+++ b/tests/muni/out/-Z11_-z11_--hilbert.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/out/-Z11_-z11_--hilbert.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z11_--prefer-radix-sort.json
+++ b/tests/muni/out/-Z11_-z11_--prefer-radix-sort.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/out/-Z11_-z11_--prefer-radix-sort.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z11_-g2.json
+++ b/tests/muni/out/-Z11_-z11_-g2.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.431641,37.788049,11",
 "description": "tests/muni/out/-Z11_-z11_-g2.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-B15.json
+++ b/tests/muni/out/-Z11_-z13_-B15.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-B15.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-Bf2000.json
+++ b/tests/muni/out/-Z11_-z13_-Bf2000.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-Bf2000.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-M10000.json
+++ b/tests/muni/out/-Z11_-z13_-M10000.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-M10000.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-M10000_-aG.json
+++ b/tests/muni/out/-Z11_-z13_-M10000_-aG.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-M10000_-aG.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-M10000_-ad.json
+++ b/tests/muni/out/-Z11_-z13_-M10000_-ad.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-M10000_-ad.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-M10000_-pd.json
+++ b/tests/muni/out/-Z11_-z13_-M10000_-pd.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-M10000_-pd.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-M5000_-as.json
+++ b/tests/muni/out/-Z11_-z13_-M5000_-as.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.497559,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-M5000_-as.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json
+++ b/tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.453613,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-rf2000.json
+++ b/tests/muni/out/-Z11_-z13_-rf2000.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-rf2000.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-rf2000_-Bg.json
+++ b/tests/muni/out/-Z11_-z13_-rf2000_-Bg.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-rf2000_-Bg.json.check.mbtiles",

--- a/tests/muni/out/-Z11_-z13_-rf2000_-g2.json
+++ b/tests/muni/out/-Z11_-z13_-rf2000_-g2.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.409668,37.770713,13",
 "description": "tests/muni/out/-Z11_-z13_-rf2000_-g2.json.check.mbtiles",

--- a/tests/muni/out/-r1_-K20.json
+++ b/tests/muni/out/-r1_-K20.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-122.420654,37.779398,14",
 "description": "tests/muni/out/-r1_-K20.json.check.mbtiles",

--- a/tests/muni/out/-z0_--coalesce_--reorder.json
+++ b/tests/muni/out/-z0_--coalesce_--reorder.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-12.240000,37.705764,0",
 "description": "tests/muni/out/-z0_--coalesce_--reorder.json.check.mbtiles",

--- a/tests/muni/out/-z1_-Z1_-ao_-P.json
+++ b/tests/muni/out/-z1_-Z1_-ao_-P.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "center": "-90.000000,37.836443,1",
 "description": "tests/muni/out/-z1_-Z1_-ao_-P.json.check.mbtiles",

--- a/tests/named/out/-z0_-Lalgeria@tests%named%alg_-Lalbania@tests%named%alb.json
+++ b/tests/named/out/-z0_-Lalgeria@tests%named%alg_-Lalbania@tests%named%alb.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-8.682385,18.975561,24.163413,69.036355",
 "bounds": "-8.682385,18.975561,24.163413,69.036355",
 "center": "0.000000,18.975561,0",
 "description": "tests/named/out/-z0_-Lalgeria@tests%named%alg_-Lalbania@tests%named%alb.json.check.mbtiles",

--- a/tests/named/out/-z0_-Lalgeria@tests%named%alg_-Lalbania@tests%named%alb_-lunified.json
+++ b/tests/named/out/-z0_-Lalgeria@tests%named%alg_-Lalbania@tests%named%alb_-lunified.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-8.682385,18.975561,24.163413,69.036355",
 "bounds": "-8.682385,18.975561,24.163413,69.036355",
 "center": "0.000000,18.975561,0",
 "description": "tests/named/out/-z0_-Lalgeria@tests%named%alg_-Lalbania@tests%named%alb_-lunified.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json
+++ b/tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json
+++ b/tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-R5%17%11.json
+++ b/tests/ne_110m_admin_0_countries/out/-R5%17%11.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-R5%17%11.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-R5%17%11.json
+++ b/tests/ne_110m_admin_0_countries/out/-R5%17%11.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-R5%17%11.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-110.039063,26.980829,-92.021484,51.998410",
 "center": "-92.021484,26.980829,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-110.039063,26.980829,-92.021484,51.998410",
 "center": "-92.021484,26.980829,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json
+++ b/tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json
+++ b/tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z3_-ai.json
+++ b/tests/ne_110m_admin_0_countries/out/-z3_-ai.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "22.500000,20.489949,3",
 "description": "tests/ne_110m_admin_0_countries/out/-z3_-ai.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z3_-ai.json
+++ b/tests/ne_110m_admin_0_countries/out/-z3_-ai.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "22.500000,20.489949,3",
 "description": "tests/ne_110m_admin_0_countries/out/-z3_-ai.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "-101.250000,70.266402,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "-101.250000,70.266402,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-zg_-yname.json
+++ b/tests/ne_110m_admin_0_countries/out/-zg_-yname.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-zg_-yname.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-zg_-yname.json
+++ b/tests/ne_110m_admin_0_countries/out/-zg_-yname.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,85.002221",
+"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-zg_-yname.json.check.mbtiles",

--- a/tests/ne_110m_admin_1_states_provinces_lines/out/-X_-z4.json
+++ b/tests/ne_110m_admin_1_states_provinces_lines/out/-X_-z4.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "center": "-78.750000,31.461472,4",
 "description": "tests/ne_110m_admin_1_states_provinces_lines/out/-X_-z4.json.check.mbtiles",

--- a/tests/ne_110m_admin_1_states_provinces_lines/out/-lcountries_-P_-Z1_-z7_-b4_-xfeaturecla_-xscalerank_-acrol_-ps.json
+++ b/tests/ne_110m_admin_1_states_provinces_lines/out/-lcountries_-P_-Z1_-z7_-b4_-xfeaturecla_-xscalerank_-acrol_-ps.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "center": "-82.968750,37.710240,7",
 "description": "tests/ne_110m_admin_1_states_provinces_lines/out/-lcountries_-P_-Z1_-z7_-b4_-xfeaturecla_-xscalerank_-acrol_-ps.json.check.mbtiles",

--- a/tests/ne_110m_admin_1_states_provinces_lines/out/-z0_--clip-bounding-box_-110,27,-92,52.json
+++ b/tests/ne_110m_admin_1_states_provinces_lines/out/-z0_--clip-bounding-box_-110,27,-92,52.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "bounds": "-110.039063,29.688053,-92.021484,48.980217",
 "center": "-92.021484,29.688053,0",
 "description": "tests/ne_110m_admin_1_states_provinces_lines/out/-z0_--clip-bounding-box_-110,27,-92,52.json.check.mbtiles",

--- a/tests/ne_110m_admin_1_states_provinces_lines/out/-z5_-M500_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_1_states_provinces_lines/out/-z5_-M500_--drop-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "center": "-118.125000,44.951199,5",
 "description": "tests/ne_110m_admin_1_states_provinces_lines/out/-z5_-M500_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_1_states_provinces_lines/out/-z5_-ymapcolor13_-ymapcolor9_-pSi_-d8_-D16.json
+++ b/tests/ne_110m_admin_1_states_provinces_lines/out/-z5_-ymapcolor13_-ymapcolor9_-pSi_-d8_-D16.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "bounds": "-124.213807,29.689480,-70.645734,49.005639",
 "center": "-84.375000,36.466030,5",
 "description": "tests/ne_110m_admin_1_states_provinces_lines/out/-z5_-ymapcolor13_-ymapcolor9_-pSi_-d8_-D16.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/--extra-detail_30_--smallest-maximum-zoom-guess_3.json
+++ b/tests/ne_110m_populated_places/out/--extra-detail_30_--smallest-maximum-zoom-guess_3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,53.746579,3",
 "description": "tests/ne_110m_populated_places/out/--extra-detail_30_--smallest-maximum-zoom-guess_3.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_2_-Bf20_-rf20_-pb.json
+++ b/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_2_-Bf20_-rf20_-pb.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_2_-Bf20_-rf20_-pb.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3.json
+++ b/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,53.746579,3",
 "description": "tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3_-Bg.json
+++ b/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3_-Bg.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,53.746579,3",
 "description": "tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3_-Bg.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3_-rp.json
+++ b/tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3_-rp.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,53.746579,3",
 "description": "tests/ne_110m_populated_places/out/--smallest-maximum-zoom-guess_3_-rp.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-r1_-z8_-J_tests%feature-filter%places-filter.json
+++ b/tests/ne_110m_populated_places/out/-r1_-z8_-J_tests%feature-filter%places-filter.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "-62.578125,17.307462,8",
 "description": "tests/ne_110m_populated_places/out/-r1_-z8_-J_tests%feature-filter%places-filter.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME.json
+++ b/tests/ne_110m_populated_places/out/-yNAME.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "-175.220564,-21.135745,14",
 "description": "tests/ne_110m_populated_places/out/-yNAME.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-Ccat_-z5.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-Ccat_-z5.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-Ccat_-z5.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z0_-c.%tests%filter%null.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z0_-c.%tests%filter%null.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z0_-c.%tests%filter%null.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z4_--no-tile-stats.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z4_--no-tile-stats.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z4_--no-tile-stats.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%remove.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%remove.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%remove.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%rename.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%rename.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%rename.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%rename_-c.%tests%filter%rename2.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%rename_-c.%tests%filter%rename2.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z4_-C.%tests%filter%rename_-c.%tests%filter%rename2.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5_--drop-denser_60.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5_--drop-denser_60.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5_--drop-denser_60.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5_--drop-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5_-B3.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5_-B3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5_-B3.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5_-c.%tests%filter%rename.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5_-c.%tests%filter%rename.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5_-c.%tests%filter%rename.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5_-ccat.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5_-ccat.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5_-ccat.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-yNAME_-z5_-r1.5.json
+++ b/tests/ne_110m_populated_places/out/-yNAME_-z5_-r1.5.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_populated_places/out/-yNAME_-z5_-r1.5.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z0_--clip-bounding-box_-110,27,-92,52.json
+++ b/tests/ne_110m_populated_places/out/-z0_--clip-bounding-box_-110,27,-92,52.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-105.029297,29.840644,-95.361328,39.774769",
 "center": "-95.361328,29.840644,0",
 "description": "tests/ne_110m_populated_places/out/-z0_--clip-bounding-box_-110,27,-92,52.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z0_--order-by_LATITUDE.json
+++ b/tests/ne_110m_populated_places/out/-z0_--order-by_LATITUDE.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_populated_places/out/-z0_--order-by_LATITUDE.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z0_--order-by_SCALERANK_--order-descending-by_LABELRANK_--order-by_LATITUDE.json
+++ b/tests/ne_110m_populated_places/out/-z0_--order-by_SCALERANK_--order-descending-by_LABELRANK_--order-by_LATITUDE.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_populated_places/out/-z0_--order-by_SCALERANK_--order-descending-by_LABELRANK_--order-by_LATITUDE.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z0_--tile-stats-attributes-limit_5_--tile-stats-sample-values-limit_200_--tile-stats-values-limit_20.json
+++ b/tests/ne_110m_populated_places/out/-z0_--tile-stats-attributes-limit_5_--tile-stats-sample-values-limit_200_--tile-stats-values-limit_20.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_populated_places/out/-z0_--tile-stats-attributes-limit_5_--tile-stats-sample-values-limit_200_--tile-stats-values-limit_20.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z0_-C.%tests%filter%null.json
+++ b/tests/ne_110m_populated_places/out/-z0_-C.%tests%filter%null.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_populated_places/out/-z0_-C.%tests%filter%null.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z0_-r1_-yNAME_-ySOV0NAME_-yELEVATION_-YNAME@City_-YSOV0NAME@Country.json
+++ b/tests/ne_110m_populated_places/out/-z0_-r1_-yNAME_-ySOV0NAME_-yELEVATION_-YNAME@City_-YSOV0NAME@Country.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_populated_places/out/-z0_-r1_-yNAME_-ySOV0NAME_-yELEVATION_-YNAME@City_-YSOV0NAME@Country.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z1_-M10000_--coalesce-smallest-as-needed.json
+++ b/tests/ne_110m_populated_places/out/-z1_-M10000_--coalesce-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "90.000000,42.525564,1",
 "description": "tests/ne_110m_populated_places/out/-z1_-M10000_--coalesce-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z1_-M10000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_populated_places/out/-z1_-M10000_--drop-smallest-as-needed.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "90.000000,42.525564,1",
 "description": "tests/ne_110m_populated_places/out/-z1_-M10000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z3_-K20_-r1_-yNAME_-k2.json
+++ b/tests/ne_110m_populated_places/out/-z3_-K20_-r1_-yNAME_-k2.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,53.746579,3",
 "description": "tests/ne_110m_populated_places/out/-z3_-K20_-r1_-yNAME_-k2.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z3_-r1_--limit-tile-feature-count_3.json
+++ b/tests/ne_110m_populated_places/out/-z3_-r1_--limit-tile-feature-count_3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "-157.500000,-20.489949,3",
 "description": "tests/ne_110m_populated_places/out/-z3_-r1_--limit-tile-feature-count_3.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z3_-r1_--limit-tile-feature-count_3_--limit-tile-feature-count-at-maximum-zoom_10.json
+++ b/tests/ne_110m_populated_places/out/-z3_-r1_--limit-tile-feature-count_3_--limit-tile-feature-count-at-maximum-zoom_10.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "-67.500000,20.489949,3",
 "description": "tests/ne_110m_populated_places/out/-z3_-r1_--limit-tile-feature-count_3_--limit-tile-feature-count-at-maximum-zoom_10.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-z4_-yNAME_-c.%tests%filter%remove.json
+++ b/tests/ne_110m_populated_places/out/-z4_-yNAME_-c.%tests%filter%remove.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_populated_places/out/-z4_-yNAME_-c.%tests%filter%remove.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-zg_-K20_-r1_-yNAME.json
+++ b/tests/ne_110m_populated_places/out/-zg_-K20_-r1_-yNAME.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,20.489949,3",
 "description": "tests/ne_110m_populated_places/out/-zg_-K20_-r1_-yNAME.json.check.mbtiles",

--- a/tests/ne_110m_populated_places/out/-zg_-K20_-r1_-yNAME_-kg.json
+++ b/tests/ne_110m_populated_places/out/-zg_-K20_-r1_-yNAME_-kg.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "bounds": "-175.220564,-41.299973,179.216647,64.150023",
 "center": "22.500000,53.746579,3",
 "description": "tests/ne_110m_populated_places/out/-zg_-K20_-r1_-yNAME_-kg.json.check.mbtiles",

--- a/tests/nested/out/-z0_--preserve-input-order.json
+++ b/tests/nested/out/-z0_--preserve-input-order.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,1.000000,1.000000",
 "bounds": "0.000000,0.000000,1.000000,1.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/nested/out/-z0_--preserve-input-order.json.check.mbtiles",

--- a/tests/nonascii/out/-z0.json
+++ b/tests/nonascii/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.238615,0.000000,0.000000,38.926337",
 "bounds": "-122.238615,0.000000,0.000000,38.926337",
 "center": "0.000000,0.000000,0",
 "description": "tests/nonascii/out/-z0.json.check.mbtiles",

--- a/tests/nullisland/out/-b0_-z4.json
+++ b/tests/nullisland/out/-b0_-z4.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-1.000000,-1.000000,1.000000,1.000000",
 "bounds": "-1.000000,-1.000000,1.000000,1.000000",
 "center": "-1.000000,1.000000,4",
 "description": "tests/nullisland/out/-b0_-z4.json.check.mbtiles",

--- a/tests/nullisland/out/-b0_-z4_-ANullIsland.json
+++ b/tests/nullisland/out/-b0_-z4_-ANullIsland.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-1.000000,-1.000000,1.000000,1.000000",
 "attribution": "NullIsland",
 "bounds": "-1.000000,-1.000000,1.000000,1.000000",
 "center": "-1.000000,1.000000,4",

--- a/tests/nullisland/out/-b0_-z4_-NNullIsland.json
+++ b/tests/nullisland/out/-b0_-z4_-NNullIsland.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-1.000000,-1.000000,1.000000,1.000000",
 "bounds": "-1.000000,-1.000000,1.000000,1.000000",
 "center": "-1.000000,1.000000,4",
 "description": "NullIsland",

--- a/tests/onefeature-point/out/--smallest-maximum-zoom-guess_3.json
+++ b/tests/onefeature-point/out/--smallest-maximum-zoom-guess_3.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.000000,37.000000,-122.000000,37.000000",
 "bounds": "-122.000000,37.000000,-122.000000,37.000000",
 "center": "-122.000000,37.000000,3",
 "description": "tests/onefeature-point/out/--smallest-maximum-zoom-guess_3.json.check.mbtiles",

--- a/tests/overflow/out/-z0.json
+++ b/tests/overflow/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,0.000000,0.000000,0.000000",
 "bounds": "0.000000,0.000000,0.000000,0.000000",
 "center": "0.000000,0.000000,0",
 "description": "tests/overflow/out/-z0.json.check.mbtiles",

--- a/tests/overlap/out/-z0.json
+++ b/tests/overlap/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-135.000000,-31.000000,-3.000000,79.000000",
 "bounds": "-135.000000,-31.000000,-3.000000,79.000000",
 "center": "-3.000000,0.000000,0",
 "description": "tests/overlap/out/-z0.json.check.mbtiles",

--- a/tests/overlap/out/-z0_--coalesce.json
+++ b/tests/overlap/out/-z0_--coalesce.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-135.000000,-31.000000,-3.000000,79.000000",
 "bounds": "-135.000000,-31.000000,-3.000000,79.000000",
 "center": "-3.000000,0.000000,0",
 "description": "tests/overlap/out/-z0_--coalesce.json.check.mbtiles",

--- a/tests/overlap/out/-z0_-pC.json
+++ b/tests/overlap/out/-z0_-pC.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-135.000000,-31.000000,-3.000000,79.000000",
 "bounds": "-135.000000,-31.000000,-3.000000,79.000000",
 "center": "-3.000000,0.000000,0",
 "description": "tests/overlap/out/-z0_-pC.json.check.mbtiles",

--- a/tests/pmtiles/hackspots.json
+++ b/tests/pmtiles/hackspots.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.682427,45.512331,-122.654961,45.569975",
 "bounds": "-122.682427,45.512331,-122.654961,45.569975",
 "center": "-122.662354,45.514045,14",
 "description": "tests/pmtiles/hackspots.pmtiles",

--- a/tests/pmtiles/joined.json
+++ b/tests/pmtiles/joined.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.695313,45.506347,-122.651367,45.583290",
 "bounds": "-122.695313,45.506347,-122.651367,45.583290",
 "center": "-122.662354,45.514045,14",
 "description": "tests/pmtiles/hackspots.pmtiles",

--- a/tests/pmtiles/joined_reordered.json
+++ b/tests/pmtiles/joined_reordered.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.695312,45.506347,-122.651367,45.583290",
 "bounds": "-122.695313,45.506347,-122.651367,45.583290",
 "center": "-122.662354,45.514045,14",
 "description": "tests/pmtiles/hackspots.mbtiles",

--- a/tests/polygon-winding/out/-z0.json
+++ b/tests/polygon-winding/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "100.000000,0.000000,101.000000,1.000000",
 "bounds": "100.000000,0.000000,101.000000,1.000000",
 "center": "100.000000,0.000000,0",
 "description": "tests/polygon-winding/out/-z0.json.check.mbtiles",

--- a/tests/polygon-winding/out/-z0_--reverse-source-polygon-winding.json
+++ b/tests/polygon-winding/out/-z0_--reverse-source-polygon-winding.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "100.000000,0.000000,101.000000,1.000000",
 "bounds": "100.000000,0.000000,101.000000,1.000000",
 "center": "100.000000,0.000000,0",
 "description": "tests/polygon-winding/out/-z0_--reverse-source-polygon-winding.json.check.mbtiles",

--- a/tests/polygon-winding/out/-z0_--use-source-polygon-winding.json
+++ b/tests/polygon-winding/out/-z0_--use-source-polygon-winding.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "100.000000,0.000000,101.000000,1.000000",
 "bounds": "100.000000,0.000000,101.000000,1.000000",
 "center": "100.000000,0.000000,0",
 "description": "tests/polygon-winding/out/-z0_--use-source-polygon-winding.json.check.mbtiles",

--- a/tests/raw-tiles/nothing.json
+++ b/tests/raw-tiles/nothing.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.000000,39.906185,0.000000,39.906185",
+"antimeridian_adjusted_bounds": "180.000000,85.051129,-180.000000,-85.051129",
 "bounds": "-180.000000,85.051129,180.000000,85.051129",
 "center": "-179.989014,85.051129,14",
 "description": "tests/raw-tiles/nothing",

--- a/tests/raw-tiles/nothing.json
+++ b/tests/raw-tiles/nothing.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.000000,39.906185,0.000000,39.906185",
 "bounds": "-180.000000,85.051129,180.000000,85.051129",
 "center": "-179.989014,85.051129,14",
 "description": "tests/raw-tiles/nothing",

--- a/tests/raw-tiles/raw-tiles-z67-join.json
+++ b/tests/raw-tiles/raw-tiles-z67-join.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-123.750000,45.089036,-120.937500,47.040182",
 "bounds": "-123.750000,45.089036,-120.937500,47.040182",
 "center": "-122.662354,45.514045,7",
 "description": "tests/raw-tiles/raw-tiles",

--- a/tests/raw-tiles/raw-tiles-z67.json
+++ b/tests/raw-tiles/raw-tiles-z67.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.682427,45.512331,-122.654961,45.569975",
 "bounds": "-122.682427,45.512331,-122.654961,45.569975",
 "center": "-122.662354,45.514045,14",
 "description": "tests/raw-tiles/raw-tiles",

--- a/tests/raw-tiles/raw-tiles.json
+++ b/tests/raw-tiles/raw-tiles.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.682427,45.512331,-122.654961,45.569975",
 "bounds": "-122.682427,45.512331,-122.654961,45.569975",
 "center": "-122.662354,45.514045,14",
 "description": "tests/raw-tiles/raw-tiles",

--- a/tests/single-polygons/out/-Z21_-zg_-D10_-d10.json
+++ b/tests/single-polygons/out/-Z21_-zg_-D10_-d10.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "174.721517,-37.166211,174.721564,-37.166209",
 "bounds": "174.721517,-37.166211,174.721564,-37.166209",
 "center": "174.721541,-37.166211,22",
 "description": "tests/single-polygons/out/-Z21_-zg_-D10_-d10.json.check.mbtiles",

--- a/tests/stable/out/-z20_-Z20.json
+++ b/tests/stable/out/-z20_-Z20.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "132.187500,-22.268764,238.000000,37.000000",
 "bounds": "-122.000000,-22.268764,132.187500,37.000000",
 "center": "132.187328,-22.268605,20",
 "description": "tests/stable/out/-z20_-Z20.json.check.mbtiles",

--- a/tests/stable/out/-z3_-B0.json
+++ b/tests/stable/out/-z3_-B0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "132.187500,-22.268764,238.000000,37.000000",
 "bounds": "-122.000000,-22.268764,132.187500,37.000000",
 "center": "112.500000,-20.489949,3",
 "description": "tests/stable/out/-z3_-B0.json.check.mbtiles",

--- a/tests/stringid/out/-z0.json
+++ b/tests/stringid/out/-z0.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0.json.check.mbtiles",

--- a/tests/stringid/out/-z0_--use-attribute-for-id_special.json
+++ b/tests/stringid/out/-z0_--use-attribute-for-id_special.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0_--use-attribute-for-id_special.json.check.mbtiles",

--- a/tests/stringid/out/-z0_--use-attribute-for-id_special_-X.json
+++ b/tests/stringid/out/-z0_--use-attribute-for-id_special_-X.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0_--use-attribute-for-id_special_-X.json.check.mbtiles",

--- a/tests/stringid/out/-z0_--use-attribute-for-id_special_-xspecial.json
+++ b/tests/stringid/out/-z0_--use-attribute-for-id_special_-xspecial.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0_--use-attribute-for-id_special_-xspecial.json.check.mbtiles",

--- a/tests/stringid/out/-z0_--use-attribute-for-id_special_-yother.json
+++ b/tests/stringid/out/-z0_--use-attribute-for-id_special_-yother.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0_--use-attribute-for-id_special_-yother.json.check.mbtiles",

--- a/tests/stringid/out/-z0_-aI.json
+++ b/tests/stringid/out/-z0_-aI.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0_-aI.json.check.mbtiles",

--- a/tests/stringid/out/-z0_-aI_--use-attribute-for-id_special.json
+++ b/tests/stringid/out/-z0_-aI_--use-attribute-for-id_special.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "1.000000,1.000000,12.000000,1.000000",
 "bounds": "1.000000,1.000000,12.000000,1.000000",
 "center": "1.000000,1.000000,0",
 "description": "tests/stringid/out/-z0_-aI_--use-attribute-for-id_special.json.check.mbtiles",

--- a/tests/tl_2015_us_county/out/-z8.json
+++ b/tests/tl_2015_us_county/out/-z8.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-70.552855,44.577264,-68.776061,46.574057",
 "bounds": "-70.552855,44.577264,-68.776061,46.574057",
 "center": "-69.609375,45.581133,8",
 "description": "tests/tl_2015_us_county/out/-z8.json.check.mbtiles",

--- a/tests/tl_2015_us_county/out/-z8_-pp.json
+++ b/tests/tl_2015_us_county/out/-z8_-pp.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-70.552855,44.577264,-68.776061,46.574057",
 "bounds": "-70.552855,44.577264,-68.776061,46.574057",
 "center": "-69.609375,45.581133,8",
 "description": "tests/tl_2015_us_county/out/-z8_-pp.json.check.mbtiles",

--- a/tests/tl_2018_51685_roads/out/-Z11_-z11_--no-simplification-of-shared-nodes.json
+++ b/tests/tl_2018_51685_roads/out/-Z11_-z11_--no-simplification-of-shared-nodes.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-77.478795,38.753598,-77.420581,38.788391",
 "bounds": "-77.478795,38.753598,-77.420581,38.788391",
 "center": "-77.431641,38.754050,11",
 "description": "tests/tl_2018_51685_roads/out/-Z11_-z11_--no-simplification-of-shared-nodes.json.check.mbtiles",

--- a/tests/wraparound/out/-z5_--detect-longitude-wraparound.json
+++ b/tests/wraparound/out/-z5_--detect-longitude-wraparound.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "177.997146,51.248410,180.003540,52.248490",
 "bounds": "-180.000000,51.248410,180.000000,52.248490",
 "center": "174.375000,52.248490,5",
 "description": "tests/wraparound/out/-z5_--detect-longitude-wraparound.json.check.mbtiles",

--- a/tests/wyalkatchem/out/-pk_-pf_-Z9_-z12_-ldata.json
+++ b/tests/wyalkatchem/out/-pk_-pf_-Z9_-z12_-ldata.json
@@ -1,4 +1,5 @@
 { "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "117.203146,-31.489159,117.498457,-31.052744",
 "bounds": "117.203146,-31.489159,117.498457,-31.052744",
 "center": "117.290039,-31.391150,12",
 "description": "tests/wyalkatchem/out/-pk_-pf_-Z9_-z12_-ldata.json.check.mbtiles",

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -1284,7 +1284,8 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, true, description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies);
+	// xxx antimeridian
+	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat, st.minlon, st.maxlat, st.maxlon, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, true, description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies);
 
 	if (outdb != NULL) {
 		mbtiles_write_metadata(outdb, m, true);

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -57,6 +57,7 @@ struct stats {
 	int maxzoom;
 	double midlat, midlon;
 	double minlat, minlon, maxlat, maxlon;
+	double minlat2, minlon2, maxlat2, maxlon2;
 	std::vector<struct strategy> strategies;
 };
 
@@ -716,6 +717,8 @@ void decode(struct reader *readers, std::map<std::string, layermap_entry> &layer
 	double minlon = INT_MAX;
 	double maxlat = INT_MIN;
 	double maxlon = INT_MIN;
+	double minlon2 = INT_MAX;
+	double maxlon2 = INT_MIN;
 	int zoom_for_bbox = -1;
 
 	while (readers != NULL && readers->zoom < 32) {
@@ -726,8 +729,8 @@ void decode(struct reader *readers, std::map<std::string, layermap_entry> &layer
 			// Only use highest zoom for bbox calculation
 			// to avoid z0 always covering the world
 
-			minlat = minlon = INT_MAX;
-			maxlat = maxlon = INT_MIN;
+			minlat = minlon = minlon2 = INT_MAX;
+			maxlat = maxlon = maxlon2 = INT_MIN;
 			zoom_for_bbox = r->zoom;
 		}
 
@@ -738,6 +741,14 @@ void decode(struct reader *readers, std::map<std::string, layermap_entry> &layer
 		minlon = min(lon1, minlon);
 		maxlat = max(lat1, maxlat);
 		maxlon = max(lon2, maxlon);
+
+		if (lon1 < 0) {
+			lon1 += 360;
+			lon2 += 360;
+		}
+
+		minlon2 = min(lon1, minlon2);
+		maxlon2 = max(lon2, maxlon2);
 
 		if (r->zoom >= minzoom && r->zoom <= maxzoom) {
 			zxy tile = zxy(r->zoom, r->x, r->y);
@@ -810,6 +821,11 @@ void decode(struct reader *readers, std::map<std::string, layermap_entry> &layer
 	st->maxlon = max(maxlon, st->maxlon);
 	st->minlat = min(minlat, st->minlat);
 	st->maxlat = max(maxlat, st->maxlat);
+
+	st->minlon2 = min(minlon2, st->minlon2);
+	st->maxlon2 = max(maxlon2, st->maxlon2);
+	st->minlat2 = min(minlat, st->minlat2);
+	st->maxlat2 = max(maxlat, st->maxlat2);
 
 	handle_tasks(tasks, layermaps, outdb, outdir, header, mapping, exclude, ifmatched, keep_layers, remove_layers, filter);
 	layermap = merge_layermaps(layermaps);
@@ -1229,8 +1245,8 @@ int main(int argc, char **argv) {
 
 	struct stats st;
 	memset(&st, 0, sizeof(st));
-	st.minzoom = st.minlat = st.minlon = INT_MAX;
-	st.maxzoom = st.maxlat = st.maxlon = INT_MIN;
+	st.minzoom = st.minlat = st.minlon = st.minlat2 = st.minlon2 = INT_MAX;
+	st.maxzoom = st.maxlat = st.maxlon = st.maxlat2 = st.maxlon2 = INT_MIN;
 
 	std::map<std::string, layermap_entry> layermap;
 	std::string attribution;
@@ -1284,8 +1300,12 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	// xxx antimeridian
-	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat, st.minlon, st.maxlat, st.maxlon, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, true, description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies);
+	if (st.maxlon - st.minlon <= st.maxlon2 - st.minlon2) {
+		st.minlon2 = st.minlon;
+		st.maxlon2 = st.maxlon;
+	}
+
+	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat2, st.minlon2, st.maxlat2, st.maxlon2, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, true, description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies);
 
 	if (outdb != NULL) {
 		mbtiles_write_metadata(outdb, m, true);

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.23.0"
+#define VERSION "v2.24.0"
 
 #endif


### PR DESCRIPTION
This allows tilesets that cross the antimeridian to have a narrower, more meaningful bounding box with longitudes in the range 0° to 360°. The mbtiles format still requires these tilesets to have a `bounds` that covers the entire range of -180° to 180°, so the new bounding box is a separate field in the metadata.