### PR TITLE
fix warning about unused pmtiles::entryv3_cmp

### DIFF
--- a/pmtiles/pmtiles.hpp
+++ b/pmtiles/pmtiles.hpp
@@ -165,11 +165,6 @@ struct entryv3 {
 	}
 };
 
-struct {
-	bool operator()(entryv3 a, entryv3 b) const {
-		return a.tile_id < b.tile_id;
-	}
-} entryv3_cmp;
 
 struct entry_zxy {
 	uint8_t z;

--- a/pmtiles_file.cpp
+++ b/pmtiles_file.cpp
@@ -11,6 +11,12 @@
 #include "mvt.hpp"
 #include "write_json.hpp"
 
+struct {
+	bool operator()(pmtiles::entryv3 a, pmtiles::entryv3 b) const {
+		return a.tile_id < b.tile_id;
+	}
+} entryv3_cmp;
+
 bool pmtiles_has_suffix(const char *filename) {
 	if (filename == nullptr) {
 		return false;
@@ -253,7 +259,7 @@ void mbtiles_map_image_to_pmtiles(char *fname, metadata m, bool tile_compression
 
 	// finalize PMTiles archive.
 	{
-		std::sort(entries.begin(), entries.end(), pmtiles::entryv3_cmp);
+		std::sort(entries.begin(), entries.end(), entryv3_cmp);
 
 		std::string root_bytes;
 		std::string leaves_bytes;


### PR DESCRIPTION
The `pmtiles/pmtiles.hpp` file defines a `pmtiles` namespace that includes a `pmtiles::entryv3_cmp` comparison function object.

This is used in `pmtiles_file.cpp`, which contains an `#include "pmtiles_file.hpp"` directive; `pmtiles_file.hpp` in turn contains a `#include "pmtiles/pmtiles.hpp"` directive, so this works.

However, `#include pmtiles/pmtiles.hpp` also appears in several other files (`decode.cpp`, `main.cpp`, and `tile_join.cpp`), resulting in compiler warnings:

```
In file included from pmtiles_file.hpp:4:0,
                 from decode.cpp:25:
pmtiles/pmtiles.hpp: At global scope:
pmtiles/pmtiles.hpp:172:3: warning: 'pmtiles::entryv3_cmp' defined but not used [-Wunused-variable]
 } entryv3_cmp;
   ^
g++  -L/usr/local/lib -g -Wall -Wshadow -Wsign-compare -Wextra -Wunreachable-code -Wuninitialized -Wshadow -O3 -DNDEBUG  -std=c++11 -o tippecanoe-decode decode.o projection.o mvt.o write_json.o text.o jsonpull/jsonpull.o dirtiles.o 
pmtiles_file.o  -lm -lz -lsqlite3
In file included from pmtiles_file.hpp:4:0,
                 from main.cpp:48:
pmtiles/pmtiles.hpp:172:3: warning: 'pmtiles::entryv3_cmp' defined but not used [-Wunused-variable]
 } entryv3_cmp;
   ^
In file included from pmtiles_file.hpp:4:0,
                 from tile-join.cpp:31:
pmtiles/pmtiles.hpp:172:3: warning: 'pmtiles::entryv3_cmp' defined but not used [-Wunused-variable]
 } entryv3_cmp;
```

This PR fixes this by moving the definition of `entryv3_cmp`,