### PR TITLE
Update makefile to use c++17 standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL = /bin/sh
 CC := $(CC)
 CXX := $(CXX)
 CFLAGS := $(CFLAGS)
-CXXFLAGS := $(CXXFLAGS) -std=c++11
+CXXFLAGS := $(CXXFLAGS) -std=c++17
 LDFLAGS := $(LDFLAGS)
 WARNING_FLAGS := -Wall -Wshadow -Wsign-compare -Wextra -Wunreachable-code -Wuninitialized -Wshadow
 RELEASE_FLAGS := -O3 -DNDEBUG


### PR DESCRIPTION
The C++ standard didn't match the utilization inside the code and would fail to compile using the original makefile