### PR TITLE
Check for nullptr in call to properties, fixes segfault.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ SHELL = /bin/sh
 # inherit from env if set
 CC := $(CC)
 CXX := $(CXX)
-CFLAGS := $(CFLAGS)
-CXXFLAGS := $(CXXFLAGS) -std=c++17
+CFLAGS := $(CFLAGS) -fPIE
+CXXFLAGS := $(CXXFLAGS) -std=c++17 -fPIE
 LDFLAGS := $(LDFLAGS)
 WARNING_FLAGS := -Wall -Wshadow -Wsign-compare -Wextra -Wunreachable-code -Wuninitialized -Wshadow
 RELEASE_FLAGS := -O3 -DNDEBUG

--- a/flatgeobuf.cpp
+++ b/flatgeobuf.cpp
@@ -151,7 +151,7 @@ void readFeature(const FlatGeobuf::Feature *feature, long long feature_sequence_
 
 	// assume tabular schema with columns in header
 	size_t p_pos = 0;
-	while (p_pos < feature->properties()->size()) {
+	while (feature->properties() && p_pos < feature->properties()->size()) {
 		uint16_t col_idx;
 		memcpy(&col_idx, feature->properties()->data() + p_pos, sizeof(col_idx));
 


### PR DESCRIPTION
- Added -fPIE as g++ 9.4.0 complained and would not link
- Prevent crash by checking for properties before dereferencing.
