### PR TITLE
Remove Can from the codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @e-n-f @joeherm @migurski @arredond @dnomadb @ChrisLoer @cduruk @ibesora
+*   @e-n-f @joeherm @migurski @arredond @dnomadb @ChrisLoer @ibesora


### PR DESCRIPTION
I am not immediately qualified to be a reviewer on this repo right now. I am still watching updates on Slack.