### PR TITLE
Updated installation instructions to include Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ significant travel corridor.
 Installation
 ------------
 
-For this fork you will need to build from the source repository:
+The easiest way to install tippecanoe on OSX is with [Homebrew](http://brew.sh/):
+
+$ brew install tippecanoe
+
+On Ubuntu it will usually be easiest to build from the source repository:
 
 ```sh
 $ git clone https://github.com/felt/tippecanoe.git


### PR DESCRIPTION
Updated the installation instructions to include the Homebrew formula.
Resolves #70 

The Homebrew formula for `tippecanoe` was switched from `mapbox/tippecanoe` over to this project on 2022-Oct-17 with Homebrew/homebrew-core@e02b07c30a47f04068536b3af70106c4b11ca14a thanks to @e-n-f .