### PR TITLE
Docs: Improve readability of values for flags in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,9 @@ If your input is formatted as newline-delimited GeoJSON, use `-P` to make input 
 
 ### Tileset description and attribution
 
- * `-n` _name_ or `--name=`_name_: Human-readable name for the tileset (default file.json)
- * `-A` _text_ or `--attribution=`_text_: Attribution (HTML) to be shown with maps that use data from this tileset.
- * `-N` _description_ or `--description=`_description_: Description for the tileset (default file.mbtiles)
+ * `-n <name>` or `--name=<name>`: Human-readable name for the tileset (default file.json)
+ * `-A <text>` or `--attribution=<text>`: Attribution (HTML) to be shown with maps that use data from this tileset.
+ * `-N <description>` or `--description=<description>`: Description for the tileset (default file.mbtiles)
 
 ### Input files and layer names
 


### PR DESCRIPTION
I want to propose to roll out the change showecased in this PR to the whole readme.

My issue is, that I find the current formatting where the example value is italic but not part of the `<code>` tag very hard to read. 

I propose to use some other way to signal that som strings are placeholder text and wrap the whole segment as a code block.


| Before |
|--------|
| <img width="832" alt="Bildschirm­foto 2023-08-28 um 11 54 58" src="https://github.com/felt/tippecanoe/assets/111561/f0b09660-4891-4dad-b852-fa8818470dbd"> | 

| After |
|--------|
| <img width="898" alt="Bildschirm­foto 2023-08-28 um 11 54 43" src="https://github.com/felt/tippecanoe/assets/111561/0942568e-dade-4853-ad61-a4ae72f24fcd"> | 

**After:**



I picked `<example_value>`, but other wrappers would be possible to, of course.

---

I did not do this for the whole readme, yet, in order to first get feedback if this PR would be welcome.
