### PR TITLE
Reduce memory use of polygon shard detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.32.1
+
+* Reduce memory usage of --no-simplification-of-shared-nodes for polygons
+
+# 2.32.0
+
+* Extend --no-simplification-of-shared-nodes to also simplify shared polygon borders consistently
+
 # 2.31.0
 
 * Fix tile-join crash when trying to join empty tilesets

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -99,17 +99,21 @@ sqlite3 *mbtiles_open(char *dbname, char **argv, int forcetable) {
 	return outdb;
 }
 
-void mbtiles_write_tile(sqlite3 *outdb, int z, int tx, int ty, const char *data, int size) {
+unsigned long long fnv1a(std::string const &s) {
 	// Store tiles by a hash of their contents (fnv1a 64-bit)
 	// http://www.isthe.com/chongo/tech/comp/fnv/
 	const unsigned long long fnv_offset_basis = 14695981039346656037u;
 	const unsigned long long fnv_prime = 1099511628211u;
 	unsigned long long h = fnv_offset_basis;
-	for (int i = 0; i < size; i++) {
-		h ^= (unsigned char) data[i];
+	for (size_t i = 0; i < s.size(); i++) {
+		h ^= (unsigned char) s[i];
 		h *= fnv_prime;
 	}
-	std::string hash = std::to_string(h);
+	return h;
+}
+
+void mbtiles_write_tile(sqlite3 *outdb, int z, int tx, int ty, const char *data, int size) {
+	std::string hash = std::to_string(fnv1a(std::string(data, size)));
 
 	// following https://github.com/mapbox/node-mbtiles/blob/master/lib/mbtiles.js
 

--- a/mbtiles.hpp
+++ b/mbtiles.hpp
@@ -85,4 +85,6 @@ std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::
 
 void add_to_file_keys(std::map<std::string, type_and_string_stats> &file_keys, std::string const &layername, type_and_string const &val);
 
+unsigned long long fnv1a(std::string const &s);
+
 #endif

--- a/tile.cpp
+++ b/tile.cpp
@@ -1295,30 +1295,31 @@ long long choose_minextent(std::vector<long long> &extents, double f) {
 }
 
 struct joint {
-	draw p1;
-	draw mid;
-	draw p2;
+	long long x : 34;  // enough to wrap around the world either way
+	long long y : 33;  // enough to touch the top and bottom of the world
+
+	unsigned long long p1p2 : 61;
 
 	joint(draw one, draw hinge, draw two) {
 		if (one < two) {
-			p1 = one;
-			p2 = two;
-		} else {
-			p1 = two;
-			p2 = one;
+			std::swap(one, two);
 		}
 
-		mid = hinge;
+		long long coord[4] = {one.x, one.y, two.x, two.y};
+		p1p2 = fnv1a(std::string((const char *) &coord, sizeof(coord)));
+
+		x = hinge.x;
+		y = hinge.y;
 	}
 
 	bool operator<(const joint &o) const {
-		if (mid < o.mid) {
+		if (y < o.y) {
 			return true;
-		} else if (mid == o.mid) {
-			if (p1 < o.p1) {
+		} else if (y == o.y) {
+			if (x < o.x) {
 				return true;
-			} else if (p1 == o.p1) {
-				if (p2 < o.p2) {
+			} else if (x == o.x) {
+				if (p1p2 < o.p1p2) {
 					return true;
 				}
 			}
@@ -2433,10 +2434,10 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 
 			std::sort(shared_joints.begin(), shared_joints.end());
 			for (size_t i = 0; i + 1 < shared_joints.size(); i++) {
-				if (shared_joints[i].mid == shared_joints[i + 1].mid) {
-					if (shared_joints[i].p1 != shared_joints[i + 1].p1 ||
-					    shared_joints[i].p2 != shared_joints[i + 1].p2) {
-						shared_nodes.push_back(shared_joints[i].mid);
+				if (shared_joints[i].x == shared_joints[i + 1].x &&
+				    shared_joints[i].y == shared_joints[i + 1].y) {
+					if (shared_joints[i].p1p2 != shared_joints[i + 1].p1p2) {
+						shared_nodes.push_back(draw(VT_MOVETO, shared_joints[i].x, shared_joints[i].y));
 					}
 				}
 			}

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.31.0"
+#define VERSION "v2.32.1"
 
 #endif


### PR DESCRIPTION
The polygon joint data structure previously used 24 bytes per vertex to store the three relevant points directly. Now it uses 16 bytes per vertex to store the central point plus two hashes for the other two coordinates.