### PR TITLE
Pull from the back of the list of tiles to overzoom, not the front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.34.1
+
+* Further improvements to tile-join speed
+
 # 2.34.0
 
 * Improve speed of overzooming in tile-join

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -380,13 +380,14 @@ double max(double a, double b) {
 struct tilecmp {
 	bool operator()(std::pair<unsigned, unsigned> const &a, std::pair<unsigned, unsigned> const &b) {
 		// must match behavior of tileset_reader::operator<()
+		// except backwards, since we are pulling from the end of the list
 
-		if (a.first < b.first) {
+		if (b.first < a.first) {
 			return true;
 		}
-		if (a.first == b.first) {
+		if (b.first == a.first) {
 			// Y sorts backwards, in TMS order
-			if (a.second > b.second) {
+			if (b.second > a.second) {
 				return true;
 			}
 		}
@@ -555,8 +556,8 @@ struct tileset_reader {
 				return;
 			}
 
-			auto xy = overzoomed_tiles.front();
-			overzoomed_tiles.erase(overzoomed_tiles.begin());
+			auto xy = overzoomed_tiles.back();
+			overzoomed_tiles.erase(overzoomed_tiles.begin() + overzoomed_tiles.size() - 1);
 
 			x = xy.first;
 			y = xy.second;
@@ -1061,7 +1062,7 @@ void decode(struct tileset_reader *readers, std::map<std::string, layermap_entry
 		// Then this tile is done and we can safely run the output queue.
 
 		if (readers == NULL || readers->zoom != current.first.z || readers->x != current.first.x || readers->y != current.first.y) {
-			if (tasks.size() > 10 * CPUS) {
+			if (tasks.size() > 100 * CPUS) {
 				dispatch_tasks(tasks, layermaps, outdb, outdir, header, mapping, exclude, include, ifmatched, keep_layers, remove_layers, filter, readers);
 				tasks.clear();
 			}

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.34.0"
+#define VERSION "v2.34.1"
 
 #endif


### PR DESCRIPTION
This makes a surprisingly large improvement to speed.

Before:
```
(.venv) Erica-Felt% ./tippecanoe --version                                                                            
tippecanoe v2.34.0
(.venv) Erica-Felt% time ./tile-join --overzoom -z16 -f -o foo.mbtiles  50707ddf-fd34-5d1f-a855-7eedba0b8e00/pmtiles/*
./tile-join --overzoom -z16 -f -o foo.mbtiles   82.53s user 4.60s system 70% cpu 2:04.14 total
```

After:
```
(.venv) Erica-Felt% ./tippecanoe --version                                                                            
tippecanoe v2.34.1
(.venv) Erica-Felt% time ./tile-join --overzoom -z16 -f -o foo.mbtiles  50707ddf-fd34-5d1f-a855-7eedba0b8e00/pmtiles/*
./tile-join --overzoom -z16 -f -o foo.mbtiles   0.90s user 0.23s system 99% cpu 1.146 total
```

(`50707ddf` is `microcuencas.zip`)