### PR TITLE
Reduce tile-join overzooming memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.37.0
+
+* Speed up tile-join overzooming and make it use less memory, by not including empty child tiles in the enumeration
+
 # 2.36.0
 
 * Make tile-join distrust the source tilesets' metadata maxzoom and minzoom

--- a/clip.cpp
+++ b/clip.cpp
@@ -754,7 +754,7 @@ static std::vector<std::pair<double, double>> clip_poly1(std::vector<std::pair<d
 
 std::string overzoom(std::string s, int oz, int ox, int oy, int nz, int nx, int ny,
 		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress,
-		     std::vector<std::pair<unsigned, unsigned>> *child_tiles) {
+		     std::vector<std::pair<unsigned, unsigned>> *next_overzoomed_tiles) {
 	mvt_tile tile;
 
 	try {
@@ -768,12 +768,12 @@ std::string overzoom(std::string s, int oz, int ox, int oy, int nz, int nx, int 
 		exit(EXIT_PROTOBUF);
 	}
 
-	return overzoom(tile, oz, ox, oy, nz, nx, ny, detail, buffer, keep, do_compress, child_tiles);
+	return overzoom(tile, oz, ox, oy, nz, nx, ny, detail, buffer, keep, do_compress, next_overzoomed_tiles);
 }
 
 std::string overzoom(mvt_tile tile, int oz, int ox, int oy, int nz, int nx, int ny,
 		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress,
-		     std::vector<std::pair<unsigned, unsigned>> *child_tiles) {
+		     std::vector<std::pair<unsigned, unsigned>> *next_overzoomed_tiles) {
 	mvt_tile outtile;
 
 	for (auto const &layer : tile.layers) {
@@ -892,7 +892,7 @@ std::string overzoom(mvt_tile tile, int oz, int ox, int oy, int nz, int nx, int 
 		}
 	}
 
-	if (child_tiles != NULL) {
+	if (next_overzoomed_tiles != NULL) {
 		// will any child tiles have features in them?
 		// find out recursively from the tile we just made.
 		//
@@ -907,7 +907,7 @@ std::string overzoom(mvt_tile tile, int oz, int ox, int oy, int nz, int nx, int 
 								     nz + 1, nx * 2 + x, ny * 2 + y,
 								     detail, buffer, keep, false, NULL);
 					if (child.size() > 0) {
-						child_tiles->emplace_back(nx * 2 + x, ny * 2 + y);
+						next_overzoomed_tiles->emplace_back(nx * 2 + x, ny * 2 + y);
 					}
 				}
 			}

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -99,9 +99,11 @@ int pnpoly(const drawvec &vert, size_t start, size_t nvert, long long testx, lon
 double distance_from_line(long long point_x, long long point_y, long long segA_x, long long segA_y, long long segB_x, long long segB_y);
 
 std::string overzoom(mvt_tile tile, int oz, int ox, int oy, int nz, int nx, int ny,
-		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress);
+		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress,
+		     std::vector<std::pair<unsigned, unsigned>> *child_tiles);
 
 std::string overzoom(std::string s, int oz, int ox, int oy, int nz, int nx, int ny,
-		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress);
+		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress,
+		     std::vector<std::pair<unsigned, unsigned>> *child_tiles);
 
 #endif

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -100,10 +100,10 @@ double distance_from_line(long long point_x, long long point_y, long long segA_x
 
 std::string overzoom(mvt_tile tile, int oz, int ox, int oy, int nz, int nx, int ny,
 		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress,
-		     std::vector<std::pair<unsigned, unsigned>> *child_tiles);
+		     std::vector<std::pair<unsigned, unsigned>> *next_overzoomed_tiles);
 
 std::string overzoom(std::string s, int oz, int ox, int oy, int nz, int nx, int ny,
 		     int detail, int buffer, std::set<std::string> const &keep, bool do_compress,
-		     std::vector<std::pair<unsigned, unsigned>> *child_tiles);
+		     std::vector<std::pair<unsigned, unsigned>> *next_overzoomed_tiles);
 
 #endif

--- a/overzoom.cpp
+++ b/overzoom.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
 		exit(EXIT_FAILURE);
 	}
 
-	std::string out = overzoom(tile, oz, ox, oy, nz, nx, ny, detail, buffer, keep, true);
+	std::string out = overzoom(tile, oz, ox, oy, nz, nx, ny, detail, buffer, keep, true, NULL);
 	fwrite(out.c_str(), sizeof(char), out.size(), f);
 	fclose(f);
 

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -433,8 +433,8 @@ struct tileset_reader {
 
 	// for overzooming
 	int maxzoom_so_far = -1;
-	std::vector<std::pair<unsigned, unsigned>> tiles_at_maxzoom_so_far;
-	std::vector<std::pair<unsigned, unsigned>> overzoomed_tiles;
+	std::vector<std::pair<unsigned short, unsigned short>> tiles_at_maxzoom_so_far;
+	std::vector<std::pair<unsigned short, unsigned short>> overzoomed_tiles;
 	bool overzoom_consumed_at_this_zoom = false;
 
 	// parent tile cache

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -433,8 +433,8 @@ struct tileset_reader {
 
 	// for overzooming
 	int maxzoom_so_far = -1;
-	std::vector<std::pair<unsigned short, unsigned short>> tiles_at_maxzoom_so_far;
-	std::vector<std::pair<unsigned short, unsigned short>> overzoomed_tiles;
+	std::vector<std::pair<unsigned, unsigned>> tiles_at_maxzoom_so_far;
+	std::vector<std::pair<unsigned, unsigned>> overzoomed_tiles;
 	bool overzoom_consumed_at_this_zoom = false;
 
 	// parent tile cache

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -659,7 +659,7 @@ struct tileset_reader {
 				}
 			}
 		} else {
-			overzoomed_tiles = next_overzoomed_tiles;
+			overzoomed_tiles = std::move(next_overzoomed_tiles);
 			next_overzoomed_tiles.clear();
 		}
 

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.36.0"
+#define VERSION "v2.37.0"
 
 #endif


### PR DESCRIPTION
When generating an overzoomed tile, check what child tiles it will have at the next zoom level, and queue only those tiles to be overzoomed at the next zoom level.