### PR TITLE
Reduce memory consumption during tiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.39.0
+
+* Reduce memory usage during tiling
+
 # 2.38.0
 
 * Tolerate polygon rings with insuffiently many points in input

--- a/tile.cpp
+++ b/tile.cpp
@@ -2753,6 +2753,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			std::string compressed;
 			std::string pbf = tile.encode();
 
+			tile.layers.clear();
+
 			if (!prevent[P_TILE_COMPRESSION]) {
 				compress(pbf, compressed, true);
 			} else {

--- a/tile.cpp
+++ b/tile.cpp
@@ -2430,7 +2430,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			}
 		}
 
-		for (size_t i = 0; i < partials.size(); i++) {
+		std::reverse(partials.begin(), partials.end());
+		for (ssize_t i = partials.size() - 1; i >= 0; i--) {
 			std::vector<drawvec> &pgeoms = partials[i].geoms;
 			signed char t = partials[i].t;
 			long long original_seq = partials[i].original_seq;
@@ -2474,6 +2475,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 					l->second.push_back(c);
 				}
 			}
+
+			partials.erase(partials.begin() + i);
 		}
 
 		partials.clear();

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.38.0"
+#define VERSION "v2.39.0"
 
 #endif


### PR DESCRIPTION
* When coalescing-as-needed, immediately drop complete geometries that are identical, since the duplicates will be collapsed later on in cleaning anyway
* When simplifying and cleaning geometries early to reduce the total memory footprint for geometry, concatenate multiple geometries together instead of preserving the individual identity of coalesced features
* When converting between feature representations within each tile (from `partial` to `coalesce` to `mvt_feature`), clear out the old representations while building the new instead of waiting to clear the old until they have all been converted