### PR TITLE
Clean up internal naming related to tilestats

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -479,10 +479,10 @@ void do_read_parallel(char *map, long long len, long long initial_offset, const 
 	sst.resize(CPUS);
 
 	pthread_t pthreads[CPUS];
-	std::vector<std::set<type_and_string> > file_subkeys;
+	std::vector<std::set<serial_val> > file_subkeys;
 
 	for (size_t i = 0; i < CPUS; i++) {
-		file_subkeys.push_back(std::set<type_and_string>());
+		file_subkeys.push_back(std::set<serial_val>());
 	}
 
 	for (size_t i = 0; i < CPUS; i++) {

--- a/main.cpp
+++ b/main.cpp
@@ -395,7 +395,7 @@ static void merge(struct mergelist *merges, size_t nmerges, unsigned char *map, 
 }
 
 struct sort_arg {
-	int task;
+	int svk;
 	int cpus;
 	long long indexpos;
 	struct mergelist *merges;
@@ -404,8 +404,8 @@ struct sort_arg {
 	long long unit;
 	int bytes;
 
-	sort_arg(int task1, int cpus1, long long indexpos1, struct mergelist *merges1, int indexfd1, size_t nmerges1, long long unit1, int bytes1)
-	    : task(task1), cpus(cpus1), indexpos(indexpos1), merges(merges1), indexfd(indexfd1), nmerges(nmerges1), unit(unit1), bytes(bytes1) {
+	sort_arg(int svk1, int cpus1, long long indexpos1, struct mergelist *merges1, int indexfd1, size_t nmerges1, long long unit1, int bytes1)
+	    : svk(svk1), cpus(cpus1), indexpos(indexpos1), merges(merges1), indexfd(indexfd1), nmerges(nmerges1), unit(unit1), bytes(bytes1) {
 	}
 };
 
@@ -413,7 +413,7 @@ void *run_sort(void *v) {
 	struct sort_arg *a = (struct sort_arg *) v;
 
 	long long start;
-	for (start = a->task * a->unit; start < a->indexpos; start += a->unit * a->cpus) {
+	for (start = a->svk * a->unit; start < a->indexpos; start += a->unit * a->cpus) {
 		long long end = start + a->unit;
 		if (end > a->indexpos) {
 			end = a->indexpos;

--- a/main.cpp
+++ b/main.cpp
@@ -395,7 +395,7 @@ static void merge(struct mergelist *merges, size_t nmerges, unsigned char *map, 
 }
 
 struct sort_arg {
-	int svk;
+	int task;
 	int cpus;
 	long long indexpos;
 	struct mergelist *merges;
@@ -404,8 +404,8 @@ struct sort_arg {
 	long long unit;
 	int bytes;
 
-	sort_arg(int svk1, int cpus1, long long indexpos1, struct mergelist *merges1, int indexfd1, size_t nmerges1, long long unit1, int bytes1)
-	    : svk(svk1), cpus(cpus1), indexpos(indexpos1), merges(merges1), indexfd(indexfd1), nmerges(nmerges1), unit(unit1), bytes(bytes1) {
+	sort_arg(int task1, int cpus1, long long indexpos1, struct mergelist *merges1, int indexfd1, size_t nmerges1, long long unit1, int bytes1)
+	    : task(task1), cpus(cpus1), indexpos(indexpos1), merges(merges1), indexfd(indexfd1), nmerges(nmerges1), unit(unit1), bytes(bytes1) {
 	}
 };
 
@@ -413,7 +413,7 @@ void *run_sort(void *v) {
 	struct sort_arg *a = (struct sort_arg *) v;
 
 	long long start;
-	for (start = a->svk * a->unit; start < a->indexpos; start += a->unit * a->cpus) {
+	for (start = a->task * a->unit; start < a->indexpos; start += a->unit * a->cpus) {
 		long long end = start + a->unit;
 		if (end > a->indexpos) {
 			end = a->indexpos;

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -196,21 +196,21 @@ void mbtiles_erase_zoom(sqlite3 *outdb, int z) {
 	}
 }
 
-bool type_and_string::operator<(const type_and_string &o) const {
-	if (string < o.string) {
+bool serial_val::operator<(const serial_val &o) const {
+	if (s < o.s) {
 		return true;
 	}
-	if (string == o.string && type < o.type) {
+	if (s == o.s && type < o.type) {
 		return true;
 	}
 	return false;
 }
 
-bool type_and_string::operator!=(const type_and_string &o) const {
+bool serial_val::operator!=(const serial_val &o) const {
 	if (type != o.type) {
 		return true;
 	}
-	if (string != o.string) {
+	if (s != o.s) {
 		return true;
 	}
 	return false;
@@ -338,15 +338,15 @@ void tilestats(std::map<std::string, layermap_entry> const &layermap1, size_t el
 					vals++;
 
 					state.nospace = true;
-					state.json_write_stringified(value.string);
+					state.json_write_stringified(value.s);
 				} else {
-					std::string trunc = truncate16(value.string, 256);
+					std::string trunc = truncate16(value.s, 256);
 
-					if (trunc.size() == value.string.size()) {
+					if (trunc.size() == value.s.size()) {
 						vals++;
 
 						state.nospace = true;
-						state.json_write_string(value.string);
+						state.json_write_string(value.s);
 					}
 				}
 			}
@@ -861,7 +861,7 @@ std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::
 				auto fk2 = out_entry->second.file_keys.find(attribname);
 
 				if (fk2 == out_entry->second.file_keys.end()) {
-					out_entry->second.file_keys.insert(std::pair<std::string, type_and_string_stats>(attribname, fk->second));
+					out_entry->second.file_keys.insert(std::pair<std::string, tilestat>(attribname, fk->second));
 				} else {
 					for (auto val : fk->second.sample_values) {
 						auto pt = std::lower_bound(fk2->second.sample_values.begin(), fk2->second.sample_values.end(), val);
@@ -901,14 +901,14 @@ std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::
 	return out;
 }
 
-void add_to_file_keys(std::map<std::string, type_and_string_stats> &file_keys, std::string const &attrib, type_and_string const &val) {
+void add_to_file_keys(std::map<std::string, tilestat> &file_keys, std::string const &attrib, serial_val const &val) {
 	if (val.type == mvt_null) {
 		return;
 	}
 
 	auto fka = file_keys.find(attrib);
 	if (fka == file_keys.end()) {
-		file_keys.insert(std::pair<std::string, type_and_string_stats>(attrib, type_and_string_stats()));
+		file_keys.insert(std::pair<std::string, tilestat>(attrib, tilestat()));
 		fka = file_keys.find(attrib);
 	}
 
@@ -918,7 +918,7 @@ void add_to_file_keys(std::map<std::string, type_and_string_stats> &file_keys, s
 	}
 
 	if (val.type == mvt_double) {
-		double d = atof(val.string.c_str());
+		double d = atof(val.s.c_str());
 
 		if (d < fka->second.min) {
 			fka->second.min = d;

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -261,7 +261,7 @@ void tilestats(std::map<std::string, layermap_entry> const &layermap1, size_t el
 		state.nospace = true;
 		state.json_write_string(geomtype);
 
-		size_t attrib_count = layer.second.file_keys.size();
+		size_t attrib_count = layer.second.tilestats.size();
 		if (attrib_count > max_tilestats_attributes) {
 			attrib_count = max_tilestats_attributes;
 		}
@@ -277,7 +277,7 @@ void tilestats(std::map<std::string, layermap_entry> const &layermap1, size_t el
 		state.json_write_array();
 
 		size_t attrs = 0;
-		for (auto attribute : layer.second.file_keys) {
+		for (auto attribute : layer.second.tilestats) {
 			if (attrs == elements) {
 				break;
 			}
@@ -745,7 +745,7 @@ metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minla
 
 				bool first = true;
 				size_t attribute_count = 0;
-				for (auto j = fk->second.file_keys.begin(); j != fk->second.file_keys.end(); ++j) {
+				for (auto j = fk->second.tilestats.begin(); j != fk->second.tilestats.end(); ++j) {
 					if (first) {
 						first = false;
 					}
@@ -852,16 +852,16 @@ std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::
 				exit(EXIT_IMPOSSIBLE);
 			}
 
-			for (auto fk = map->second.file_keys.begin(); fk != map->second.file_keys.end(); ++fk) {
+			for (auto fk = map->second.tilestats.begin(); fk != map->second.tilestats.end(); ++fk) {
 				std::string attribname = fk->first;
 				if (trunc) {
 					attribname = truncate16(attribname, 256);
 				}
 
-				auto fk2 = out_entry->second.file_keys.find(attribname);
+				auto fk2 = out_entry->second.tilestats.find(attribname);
 
-				if (fk2 == out_entry->second.file_keys.end()) {
-					out_entry->second.file_keys.insert(std::pair<std::string, tilestat>(attribname, fk->second));
+				if (fk2 == out_entry->second.tilestats.end()) {
+					out_entry->second.tilestats.insert(std::pair<std::string, tilestat>(attribname, fk->second));
 				} else {
 					for (auto val : fk->second.sample_values) {
 						auto pt = std::lower_bound(fk2->second.sample_values.begin(), fk2->second.sample_values.end(), val);
@@ -901,18 +901,18 @@ std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::
 	return out;
 }
 
-void add_to_file_keys(std::map<std::string, tilestat> &file_keys, std::string const &attrib, serial_val const &val) {
+void add_to_tilestats(std::map<std::string, tilestat> &tilestats, std::string const &attrib, serial_val const &val) {
 	if (val.type == mvt_null) {
 		return;
 	}
 
-	auto fka = file_keys.find(attrib);
-	if (fka == file_keys.end()) {
-		file_keys.insert(std::pair<std::string, tilestat>(attrib, tilestat()));
-		fka = file_keys.find(attrib);
+	auto fka = tilestats.find(attrib);
+	if (fka == tilestats.end()) {
+		tilestats.insert(std::pair<std::string, tilestat>(attrib, tilestat()));
+		fka = tilestats.find(attrib);
 	}
 
-	if (fka == file_keys.end()) {
+	if (fka == tilestats.end()) {
 		fprintf(stderr, "Can't happen (tilestats)\n");
 		exit(EXIT_IMPOSSIBLE);
 	}

--- a/mbtiles.hpp
+++ b/mbtiles.hpp
@@ -9,16 +9,8 @@ extern size_t max_tilestats_attributes;
 extern size_t max_tilestats_sample_values;
 extern size_t max_tilestats_values;
 
-struct type_and_string {
-	int type = 0;
-	std::string string = "";
-
-	bool operator<(const type_and_string &o) const;
-	bool operator!=(const type_and_string &o) const;
-};
-
-struct type_and_string_stats {
-	std::vector<type_and_string> sample_values = std::vector<type_and_string>();  // sorted
+struct tilestat {
+	std::vector<serial_val> sample_values = std::vector<serial_val>();  // sorted
 	double min = INFINITY;
 	double max = -INFINITY;
 	int type = 0;
@@ -26,7 +18,7 @@ struct type_and_string_stats {
 
 struct layermap_entry {
 	size_t id = 0;
-	std::map<std::string, type_and_string_stats> file_keys{};
+	std::map<std::string, tilestat> file_keys{};
 	int minzoom = 0;
 	int maxzoom = 0;
 	std::string description = "";
@@ -84,7 +76,7 @@ void mbtiles_close(sqlite3 *outdb, const char *pgm);
 std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::string, layermap_entry> > const &maps);
 std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::string, layermap_entry> > const &maps, bool trunc);
 
-void add_to_file_keys(std::map<std::string, type_and_string_stats> &file_keys, std::string const &layername, type_and_string const &val);
+void add_to_file_keys(std::map<std::string, tilestat> &file_keys, std::string const &layername, serial_val const &val);
 
 unsigned long long fnv1a(std::string const &s);
 

--- a/mbtiles.hpp
+++ b/mbtiles.hpp
@@ -18,7 +18,7 @@ struct tilestat {
 
 struct layermap_entry {
 	size_t id = 0;
-	std::map<std::string, tilestat> file_keys{};
+	std::map<std::string, tilestat> tilestats{};
 	int minzoom = 0;
 	int maxzoom = 0;
 	std::string description = "";
@@ -76,7 +76,7 @@ void mbtiles_close(sqlite3 *outdb, const char *pgm);
 std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::string, layermap_entry> > const &maps);
 std::map<std::string, layermap_entry> merge_layermaps(std::vector<std::map<std::string, layermap_entry> > const &maps, bool trunc);
 
-void add_to_file_keys(std::map<std::string, tilestat> &file_keys, std::string const &layername, serial_val const &val);
+void add_to_tilestats(std::map<std::string, tilestat> &tilestats, std::string const &layername, serial_val const &val);
 
 unsigned long long fnv1a(std::string const &s);
 

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -274,9 +274,9 @@ std::vector<mvt_layer> parse_layers(int fd, int z, unsigned x, unsigned y, std::
 					mvt_value v = stringified_to_mvt_value(tp, s.c_str());
 					l->second.tag(feature, std::string(properties->value.object.keys[i]->value.string.string), v);
 
-					type_and_string attrib;
+					serial_val attrib;
 					attrib.type = tp;
-					attrib.string = s;
+					attrib.s = s;
 
 					add_to_file_keys(fk->second.file_keys, std::string(properties->value.object.keys[i]->value.string.string), attrib);
 				}
@@ -515,8 +515,8 @@ serial_feature parse_feature(json_pull *jp, int z, unsigned x, unsigned y, std::
 					sf.full_keys.push_back(std::string(properties->value.object.keys[i]->value.string.string));
 					sf.full_values.push_back(v);
 
-					type_and_string attrib;
-					attrib.string = v.s;
+					serial_val attrib;
+					attrib.s = v.s;
 					attrib.type = v.type;
 
 					if (!postfilter) {

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -241,24 +241,24 @@ std::vector<mvt_layer> parse_layers(int fd, int z, unsigned x, unsigned y, std::
 				}
 			}
 
-			auto fk = layermap.find(layername);
-			if (fk == layermap.end()) {
+			auto ts = layermap.find(layername);
+			if (ts == layermap.end()) {
 				fprintf(stderr, "Internal error: layer %s not found\n", layername.c_str());
 				exit(EXIT_IMPOSSIBLE);
 			}
-			if (z < fk->second.minzoom) {
-				fk->second.minzoom = z;
+			if (z < ts->second.minzoom) {
+				ts->second.minzoom = z;
 			}
-			if (z > fk->second.maxzoom) {
-				fk->second.maxzoom = z;
+			if (z > ts->second.maxzoom) {
+				ts->second.maxzoom = z;
 			}
 
 			if (feature.type == mvt_point) {
-				fk->second.points++;
+				ts->second.points++;
 			} else if (feature.type == mvt_linestring) {
-				fk->second.lines++;
+				ts->second.lines++;
 			} else if (feature.type == mvt_polygon) {
-				fk->second.polygons++;
+				ts->second.polygons++;
 			}
 
 			for (size_t i = 0; i < properties->value.object.length; i++) {
@@ -278,7 +278,7 @@ std::vector<mvt_layer> parse_layers(int fd, int z, unsigned x, unsigned y, std::
 					attrib.type = tp;
 					attrib.s = s;
 
-					add_to_tilestats(fk->second.tilestats, std::string(properties->value.object.keys[i]->value.string.string), attrib);
+					add_to_tilestats(ts->second.tilestats, std::string(properties->value.object.keys[i]->value.string.string), attrib);
 				}
 			}
 
@@ -478,27 +478,27 @@ serial_feature parse_feature(json_pull *jp, int z, unsigned x, unsigned y, std::
 				}
 			}
 
-			auto fk = layermap.find(layername);
-			if (fk == layermap.end()) {
+			auto ts = layermap.find(layername);
+			if (ts == layermap.end()) {
 				fprintf(stderr, "Internal error: layer %s not found\n", layername.c_str());
 				exit(EXIT_IMPOSSIBLE);
 			}
-			sf.layer = fk->second.id;
+			sf.layer = ts->second.id;
 
-			if (z < fk->second.minzoom) {
-				fk->second.minzoom = z;
+			if (z < ts->second.minzoom) {
+				ts->second.minzoom = z;
 			}
-			if (z > fk->second.maxzoom) {
-				fk->second.maxzoom = z;
+			if (z > ts->second.maxzoom) {
+				ts->second.maxzoom = z;
 			}
 
 			if (!postfilter) {
 				if (sf.t == mvt_point) {
-					fk->second.points++;
+					ts->second.points++;
 				} else if (sf.t == mvt_linestring) {
-					fk->second.lines++;
+					ts->second.lines++;
 				} else if (sf.t == mvt_polygon) {
-					fk->second.polygons++;
+					ts->second.polygons++;
 				}
 			}
 
@@ -520,7 +520,7 @@ serial_feature parse_feature(json_pull *jp, int z, unsigned x, unsigned y, std::
 					attrib.type = v.type;
 
 					if (!postfilter) {
-						add_to_tilestats(fk->second.tilestats, std::string(properties->value.object.keys[i]->value.string.string), attrib);
+						add_to_tilestats(ts->second.tilestats, std::string(properties->value.object.keys[i]->value.string.string), attrib);
 					}
 				}
 			}

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -278,7 +278,7 @@ std::vector<mvt_layer> parse_layers(int fd, int z, unsigned x, unsigned y, std::
 					attrib.type = tp;
 					attrib.s = s;
 
-					add_to_file_keys(fk->second.file_keys, std::string(properties->value.object.keys[i]->value.string.string), attrib);
+					add_to_tilestats(fk->second.tilestats, std::string(properties->value.object.keys[i]->value.string.string), attrib);
 				}
 			}
 
@@ -520,7 +520,7 @@ serial_feature parse_feature(json_pull *jp, int z, unsigned x, unsigned y, std::
 					attrib.type = v.type;
 
 					if (!postfilter) {
-						add_to_file_keys(fk->second.file_keys, std::string(properties->value.object.keys[i]->value.string.string), attrib);
+						add_to_tilestats(fk->second.tilestats, std::string(properties->value.object.keys[i]->value.string.string), attrib);
 					}
 				}
 			}

--- a/serial.cpp
+++ b/serial.cpp
@@ -827,8 +827,8 @@ int serialize_feature(struct serialization_state *sst, serial_feature &sf) {
 
 	if (!sst->filters) {
 		for (size_t i = 0; i < sf.full_keys.size(); i++) {
-			auto fk = sst->layermap->find(sf.layername);
-			add_to_tilestats(fk->second.tilestats, sf.full_keys[i], sf.full_values[i]);
+			auto ts = sst->layermap->find(sf.layername);
+			add_to_tilestats(ts->second.tilestats, sf.full_keys[i], sf.full_values[i]);
 		}
 	}
 

--- a/serial.cpp
+++ b/serial.cpp
@@ -828,7 +828,7 @@ int serialize_feature(struct serialization_state *sst, serial_feature &sf) {
 	if (!sst->filters) {
 		for (size_t i = 0; i < sf.full_keys.size(); i++) {
 			auto fk = sst->layermap->find(sf.layername);
-			add_to_file_keys(fk->second.file_keys, sf.full_keys[i], sf.full_values[i]);
+			add_to_tilestats(fk->second.tilestats, sf.full_keys[i], sf.full_values[i]);
 		}
 	}
 

--- a/serial.cpp
+++ b/serial.cpp
@@ -827,12 +827,8 @@ int serialize_feature(struct serialization_state *sst, serial_feature &sf) {
 
 	if (!sst->filters) {
 		for (size_t i = 0; i < sf.full_keys.size(); i++) {
-			type_and_string attrib;
-			attrib.type = sf.full_values[i].type;
-			attrib.string = sf.full_values[i].s;
-
 			auto fk = sst->layermap->find(sf.layername);
-			add_to_file_keys(fk->second.file_keys, sf.full_keys[i], attrib);
+			add_to_file_keys(fk->second.file_keys, sf.full_keys[i], sf.full_values[i]);
 		}
 	}
 

--- a/serial.hpp
+++ b/serial.hpp
@@ -38,6 +38,9 @@ void deserialize_byte(char **f, signed char *n);
 struct serial_val {
 	int type = 0;
 	std::string s = "";
+
+	bool operator<(const serial_val &o) const;
+	bool operator!=(const serial_val &o) const;
 };
 
 struct serial_feature {

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -167,7 +167,7 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 				outfeature.id = feat.id;
 			}
 
-			std::map<std::string, std::pair<mvt_value, type_and_string>> attributes;
+			std::map<std::string, std::pair<mvt_value, serial_val>> attributes;
 			std::vector<std::string> key_order;
 
 			for (size_t t = 0; t + 1 < feat.tags.size(); t += 2) {
@@ -206,11 +206,11 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 				}
 
 				if (include.count(std::string(key)) || (!exclude_all && exclude.count(std::string(key)) == 0 && exclude_attributes.count(std::string(key)) == 0)) {
-					type_and_string tas;
+					serial_val tas;
 					tas.type = type;
-					tas.string = value;
+					tas.s = value;
 
-					attributes.insert(std::pair<std::string, std::pair<mvt_value, type_and_string>>(key, std::pair<mvt_value, type_and_string>(val, tas)));
+					attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(key, std::pair<mvt_value, serial_val>(val, tas)));
 					key_order.push_back(key);
 				}
 
@@ -253,14 +253,14 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 									attributes.erase(fa);
 								}
 
-								type_and_string tas;
+								serial_val tas;
 								tas.type = outval.type;
-								tas.string = joinval;
+								tas.s = joinval;
 
 								// Convert from double to int if the joined attribute is an integer
 								outval = stringified_to_mvt_value(outval.type, joinval.c_str());
 
-								attributes.insert(std::pair<std::string, std::pair<mvt_value, type_and_string>>(joinkey, std::pair<mvt_value, type_and_string>(outval, tas)));
+								attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(joinkey, std::pair<mvt_value, serial_val>(outval, tas)));
 								key_order.push_back(joinkey);
 							}
 						}

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -149,7 +149,7 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 			}
 		}
 
-		auto file_keys = layermap.find(layer.name);
+		auto tilestats = layermap.find(layer.name);
 
 		for (size_t f = 0; f < layer.features.size(); f++) {
 			mvt_feature feat = layer.features[f];
@@ -269,11 +269,11 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 			}
 
 			if (matched || !ifmatched) {
-				if (file_keys == layermap.end()) {
+				if (tilestats == layermap.end()) {
 					layermap.insert(std::pair<std::string, layermap_entry>(layer.name, layermap_entry(layermap.size())));
-					file_keys = layermap.find(layer.name);
-					file_keys->second.minzoom = z;
-					file_keys->second.maxzoom = z;
+					tilestats = layermap.find(layer.name);
+					tilestats->second.minzoom = z;
+					tilestats->second.maxzoom = z;
 				}
 
 				// To keep attributes in their original order instead of alphabetical
@@ -282,7 +282,7 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 
 					if (fa != attributes.end()) {
 						outlayer.tag(outfeature, k, fa->second.first);
-						add_to_file_keys(file_keys->second.file_keys, k, fa->second.second);
+						add_to_tilestats(tilestats->second.tilestats, k, fa->second.second);
 						attributes.erase(fa);
 					}
 				}
@@ -300,19 +300,19 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 				features_added++;
 				outlayer.features.push_back(outfeature);
 
-				if (z < file_keys->second.minzoom) {
-					file_keys->second.minzoom = z;
+				if (z < tilestats->second.minzoom) {
+					tilestats->second.minzoom = z;
 				}
-				if (z > file_keys->second.maxzoom) {
-					file_keys->second.maxzoom = z;
+				if (z > tilestats->second.maxzoom) {
+					tilestats->second.maxzoom = z;
 				}
 
 				if (feat.type == mvt_point) {
-					file_keys->second.points++;
+					tilestats->second.points++;
 				} else if (feat.type == mvt_linestring) {
-					file_keys->second.lines++;
+					tilestats->second.lines++;
 				} else if (feat.type == mvt_polygon) {
-					file_keys->second.polygons++;
+					tilestats->second.polygons++;
 				}
 			}
 		}

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -206,11 +206,11 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 				}
 
 				if (include.count(std::string(key)) || (!exclude_all && exclude.count(std::string(key)) == 0 && exclude_attributes.count(std::string(key)) == 0)) {
-					serial_val tas;
-					tas.type = type;
-					tas.s = value;
+					serial_val sv;
+					sv.type = type;
+					sv.s = value;
 
-					attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(key, std::pair<mvt_value, serial_val>(val, tas)));
+					attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(key, std::pair<mvt_value, serial_val>(val, sv)));
 					key_order.push_back(key);
 				}
 
@@ -253,14 +253,14 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 									attributes.erase(fa);
 								}
 
-								serial_val tas;
-								tas.type = outval.type;
-								tas.s = joinval;
+								serial_val sv;
+								sv.type = outval.type;
+								sv.s = joinval;
 
 								// Convert from double to int if the joined attribute is an integer
 								outval = stringified_to_mvt_value(outval.type, joinval.c_str());
 
-								attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(joinkey, std::pair<mvt_value, serial_val>(outval, tas)));
+								attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(joinkey, std::pair<mvt_value, serial_val>(outval, sv)));
 								key_order.push_back(joinkey);
 							}
 						}
@@ -821,7 +821,7 @@ void *join_worker(void *v) {
 	return NULL;
 }
 
-void dispatch_tasks(std::map<zxy, std::vector<std::string>> &tasks, std::vector<std::map<std::string, layermap_entry>> &layermaps, sqlite3 *outdb, const char *outdir, std::vector<std::string> &header, std::map<std::string, std::vector<std::string>> &mapping, std::set<std::string> &exclude, std::set<std::string> &include, int ifmatched, std::set<std::string> &keep_layers, std::set<std::string> &remove_layers, json_object *filter, struct tileset_reader *readers) {
+void dispatch_svks(std::map<zxy, std::vector<std::string>> &svks, std::vector<std::map<std::string, layermap_entry>> &layermaps, sqlite3 *outdb, const char *outdir, std::vector<std::string> &header, std::map<std::string, std::vector<std::string>> &mapping, std::set<std::string> &exclude, std::set<std::string> &include, int ifmatched, std::set<std::string> &keep_layers, std::set<std::string> &remove_layers, json_object *filter, struct tileset_reader *readers) {
 	pthread_t pthreads[CPUS];
 	std::vector<arg> args;
 
@@ -841,14 +841,14 @@ void dispatch_tasks(std::map<zxy, std::vector<std::string>> &tasks, std::vector<
 	}
 
 	size_t count = 0;
-	// This isn't careful about distributing tasks evenly across CPUs,
+	// This isn't careful about distributing svks evenly across CPUs,
 	// but, from testing, it actually takes a little longer to do
 	// the proper allocation than is saved by perfectly balanced threads.
-	for (auto ai = tasks.begin(); ai != tasks.end(); ++ai) {
+	for (auto ai = svks.begin(); ai != svks.end(); ++ai) {
 		args[count].inputs.insert(*ai);
 		count = (count + 1) % CPUS;
 
-		if (ai == tasks.begin()) {
+		if (ai == svks.begin()) {
 			if (!quiet) {
 				fprintf(stderr, "%lld/%lld/%lld  \r", ai->first.z, ai->first.x, ai->first.y);
 				fflush(stderr);
@@ -975,7 +975,7 @@ void decode(struct tileset_reader *readers, std::map<std::string, layermap_entry
 		layermaps.push_back(std::map<std::string, layermap_entry>());
 	}
 
-	std::map<zxy, std::vector<std::string>> tasks;
+	std::map<zxy, std::vector<std::string>> svks;
 	double minlat = INT_MAX;
 	double minlon = INT_MAX;
 	double maxlat = INT_MIN;
@@ -1014,14 +1014,14 @@ void decode(struct tileset_reader *readers, std::map<std::string, layermap_entry
 
 		if (current.first.z >= minzoom && current.first.z <= maxzoom) {
 			zxy tile = current.first;
-			if (tasks.count(tile) == 0) {
-				tasks.insert(std::pair<zxy, std::vector<std::string>>(tile, std::vector<std::string>()));
+			if (svks.count(tile) == 0) {
+				svks.insert(std::pair<zxy, std::vector<std::string>>(tile, std::vector<std::string>()));
 			}
-			auto f = tasks.find(tile);
+			auto f = svks.find(tile);
 			f->second.push_back(current.second);
 		}
 
-		// Advance the tileset_reader that we just added as a task.
+		// Advance the tileset_reader that we just added as a svk.
 		// The reason this prefetches is so the tileset_reader queue can be
 		// priority-ordered, so the one with the next relevant tile
 		// is first in line.
@@ -1037,9 +1037,9 @@ void decode(struct tileset_reader *readers, std::map<std::string, layermap_entry
 		// Then this tile is done and we can safely run the output queue.
 
 		if (readers == NULL || readers->zoom != current.first.z || readers->x != current.first.x || readers->y != current.first.y) {
-			if (tasks.size() > 100 * CPUS) {
-				dispatch_tasks(tasks, layermaps, outdb, outdir, header, mapping, exclude, include, ifmatched, keep_layers, remove_layers, filter, readers);
-				tasks.clear();
+			if (svks.size() > 100 * CPUS) {
+				dispatch_svks(svks, layermaps, outdb, outdir, header, mapping, exclude, include, ifmatched, keep_layers, remove_layers, filter, readers);
+				svks.clear();
 			}
 		}
 
@@ -1067,7 +1067,7 @@ void decode(struct tileset_reader *readers, std::map<std::string, layermap_entry
 	st->minlat2 = min(minlat, st->minlat2);
 	st->maxlat2 = max(maxlat, st->maxlat2);
 
-	dispatch_tasks(tasks, layermaps, outdb, outdir, header, mapping, exclude, include, ifmatched, keep_layers, remove_layers, filter, readers);
+	dispatch_svks(svks, layermaps, outdb, outdir, header, mapping, exclude, include, ifmatched, keep_layers, remove_layers, filter, readers);
 	layermap = merge_layermaps(layermaps);
 
 	struct tileset_reader *next;

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -206,11 +206,11 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 				}
 
 				if (include.count(std::string(key)) || (!exclude_all && exclude.count(std::string(key)) == 0 && exclude_attributes.count(std::string(key)) == 0)) {
-					serial_val tas;
-					tas.type = type;
-					tas.s = value;
+					serial_val sv;
+					sv.type = type;
+					sv.s = value;
 
-					attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(key, std::pair<mvt_value, serial_val>(val, tas)));
+					attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(key, std::pair<mvt_value, serial_val>(val, sv)));
 					key_order.push_back(key);
 				}
 
@@ -253,14 +253,14 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 									attributes.erase(fa);
 								}
 
-								serial_val tas;
-								tas.type = outval.type;
-								tas.s = joinval;
+								serial_val sv;
+								sv.type = outval.type;
+								sv.s = joinval;
 
 								// Convert from double to int if the joined attribute is an integer
 								outval = stringified_to_mvt_value(outval.type, joinval.c_str());
 
-								attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(joinkey, std::pair<mvt_value, serial_val>(outval, tas)));
+								attributes.insert(std::pair<std::string, std::pair<mvt_value, serial_val>>(joinkey, std::pair<mvt_value, serial_val>(outval, sv)));
 								key_order.push_back(joinkey);
 							}
 						}

--- a/tile.cpp
+++ b/tile.cpp
@@ -546,8 +546,8 @@ struct partial {
 
 struct partial_arg {
 	std::vector<struct partial> *partials = NULL;
-	int svk = 0;
-	int svks = 0;
+	int task = 0;
+	int tasks = 0;
 
 	drawvec *shared_nodes;
 	node *shared_nodes_map;
@@ -672,7 +672,7 @@ void *partial_feature_worker(void *v) {
 	struct partial_arg *a = (struct partial_arg *) v;
 	std::vector<struct partial> *partials = a->partials;
 
-	for (size_t i = a->svk; i < (*partials).size(); i += a->svks) {
+	for (size_t i = a->task; i < (*partials).size(); i += a->tasks) {
 		double area = simplify_partial(&((*partials)[i]), *(a->shared_nodes), a->shared_nodes_map, a->nodepos);
 
 		signed char t = (*partials)[i].t;
@@ -1367,7 +1367,7 @@ long long choose_minextent(std::vector<long long> &extents, double f) {
 }
 
 struct write_tile_args {
-	struct svk *svks = NULL;
+	struct task *tasks = NULL;
 	char *stringpool = NULL;
 	int min_detail = 0;
 	sqlite3 *outdb = NULL;
@@ -2557,23 +2557,23 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			find_common_edges(partials, z, line_detail, simplification, maxzoom, merge_fraction);
 		}
 
-		int svks = ceil((double) CPUS / *running);
-		if (svks < 1) {
-			svks = 1;
+		int tasks = ceil((double) CPUS / *running);
+		if (tasks < 1) {
+			tasks = 1;
 		}
 
-		pthread_t pthreads[svks];
+		pthread_t pthreads[tasks];
 		std::vector<partial_arg> args;
-		args.resize(svks);
-		for (int i = 0; i < svks; i++) {
-			args[i].svk = i;
-			args[i].svks = svks;
+		args.resize(tasks);
+		for (int i = 0; i < tasks; i++) {
+			args[i].task = i;
+			args[i].tasks = tasks;
 			args[i].partials = &partials;
 			args[i].shared_nodes = &shared_nodes;
 			args[i].shared_nodes_map = shared_nodes_map;
 			args[i].nodepos = nodepos;
 
-			if (svks > 1) {
+			if (tasks > 1) {
 				if (pthread_create(&pthreads[i], NULL, partial_feature_worker, &args[i]) != 0) {
 					perror("pthread_create");
 					exit(EXIT_PTHREAD);
@@ -2583,8 +2583,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			}
 		}
 
-		if (svks > 1) {
-			for (int i = 0; i < svks; i++) {
+		if (tasks > 1) {
+			for (int i = 0; i < tasks; i++) {
 				void *retval;
 
 				if (pthread_join(pthreads[i], &retval) != 0) {
@@ -3055,17 +3055,17 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 	return -1;
 }
 
-struct svk {
+struct task {
 	int fileno = 0;
-	struct svk *next = NULL;
+	struct task *next = NULL;
 };
 
 void *run_thread(void *vargs) {
 	write_tile_args *arg = (write_tile_args *) vargs;
-	struct svk *svk;
+	struct task *task;
 
-	for (svk = arg->svks; svk != NULL; svk = svk->next) {
-		int j = svk->fileno;
+	for (task = arg->tasks; task != NULL; task = task->next) {
+		int j = task->fileno;
 
 		if (arg->geomfd[j] < 0) {
 			// only one source file for zoom level 0
@@ -3275,11 +3275,11 @@ int traverse_zooms(int *geomfd, off_t *geom_size, char *stringpool, std::atomic<
 
 		// Assign temporary files to threads
 
-		std::vector<struct svk> svks;
-		svks.resize(TEMP_FILES);
+		std::vector<struct task> tasks;
+		tasks.resize(TEMP_FILES);
 
 		struct dispatch {
-			struct svk *svks = NULL;
+			struct task *tasks = NULL;
 			long long todo = 0;
 			struct dispatch *next = NULL;
 		};
@@ -3288,7 +3288,7 @@ int traverse_zooms(int *geomfd, off_t *geom_size, char *stringpool, std::atomic<
 
 		struct dispatch *dispatch_head = &dispatches[0];
 		for (size_t j = 0; j < threads; j++) {
-			dispatches[j].svks = NULL;
+			dispatches[j].tasks = NULL;
 			dispatches[j].todo = 0;
 			if (j + 1 < threads) {
 				dispatches[j].next = &dispatches[j + 1];
@@ -3302,9 +3302,9 @@ int traverse_zooms(int *geomfd, off_t *geom_size, char *stringpool, std::atomic<
 				continue;
 			}
 
-			svks[j].fileno = j;
-			svks[j].next = dispatch_head->svks;
-			dispatch_head->svks = &svks[j];
+			tasks[j].fileno = j;
+			tasks[j].next = dispatch_head->tasks;
+			dispatch_head->tasks = &tasks[j];
 			dispatch_head->todo += geom_size[j];
 
 			struct dispatch *here = dispatch_head;
@@ -3386,7 +3386,7 @@ int traverse_zooms(int *geomfd, off_t *geom_size, char *stringpool, std::atomic<
 				args[thread].attribute_accum = attribute_accum;
 				args[thread].filter = filter;
 
-				args[thread].svks = dispatches[thread].svks;
+				args[thread].tasks = dispatches[thread].tasks;
 				args[thread].running = &running;
 				args[thread].pass = pass;
 				args[thread].wrote_zoom = -1;

--- a/tile.cpp
+++ b/tile.cpp
@@ -1822,7 +1822,7 @@ void add_tilestats(std::string const &layername, int z, std::vector<std::map<std
 		exit(EXIT_IMPOSSIBLE);
 	}
 
-	add_to_file_keys(fk->second.file_keys, key, val);
+	add_to_tilestats(fk->second.tilestats, key, val);
 }
 
 void preserve_attribute(attribute_op op, serial_feature &, char *stringpool, long long *pool_off, std::string &key, serial_val &val, partial &p) {

--- a/tile.cpp
+++ b/tile.cpp
@@ -1816,13 +1816,13 @@ void add_tilestats(std::string const &layername, int z, std::vector<std::map<std
 			(*layer_unmaps)[tiling_seg][lme.id] = layername;
 		}
 	}
-	auto fk = layermap.find(layername);
-	if (fk == layermap.end()) {
+	auto ts = layermap.find(layername);
+	if (ts == layermap.end()) {
 		fprintf(stderr, "Internal error: layer %s not found\n", layername.c_str());
 		exit(EXIT_IMPOSSIBLE);
 	}
 
-	add_to_tilestats(fk->second.tilestats, key, val);
+	add_to_tilestats(ts->second.tilestats, key, val);
 }
 
 void preserve_attribute(attribute_op op, serial_feature &, char *stringpool, long long *pool_off, std::string &key, serial_val &val, partial &p) {

--- a/tile.cpp
+++ b/tile.cpp
@@ -1822,11 +1822,7 @@ void add_tilestats(std::string const &layername, int z, std::vector<std::map<std
 		exit(EXIT_IMPOSSIBLE);
 	}
 
-	type_and_string attrib;
-	attrib.type = val.type;
-	attrib.string = val.s;
-
-	add_to_file_keys(fk->second.file_keys, key, attrib);
+	add_to_file_keys(fk->second.file_keys, key, val);
 }
 
 void preserve_attribute(attribute_op op, serial_feature &, char *stringpool, long long *pool_off, std::string &key, serial_val &val, partial &p) {


### PR DESCRIPTION
Renames internal types and variables related to tilestats:

* `type_and_string` is merged into `serial_val`
* `type_and_string_stats` becomes `tilestat` (singular, for a single attribute)
* `file_keys` becomes `tilestats`