### PR TITLE
[ci] test in debug mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,10 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['Release', 'Debug']
     steps:
       - uses: actions/checkout@v3
-      - run: uname -a; make
+      - run: uname -a; BUILDTYPE=${{ matrix.version }} make
       - run: make test


### PR DESCRIPTION
This adds a 2nd test run on CI to compile and test the project in debug mode (un-optimized binaries). In my experience sometimes C/C++ bugs can manifest more clearly in debug mode (or even break tests in debug mode while they still pass in release mode). The usefulness of this therefore, that this additional testing may help catch bugs on CI in the future.

The CI runs will take longer. If this slowness presents a problem, or undesirable wait, we could change the `Makefile` to build debug binaries with `-O1` instead of the default of `-O1` so the tests run slightly faster.