### PR TITLE
highz precision values

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ zoom level | precision (ft) | precision (m) | map scale
 `-z18` | 1.5 in | 4 cm | 1:1250
 `-z19` | 0.8 in | 2 cm | 1:600
 `-z20` | 0.4 in | 1 cm | 1:300
-`-z21` | 0.2 in | 0.5 cm | 1:150
-`-z22` | 0.1 in | 0.25 cm | 1:75
+`-z21` | 0.4 in | 1 cm | 1:300
+`-z22` | 0.4 in | 1 cm | 1:300
 
 ### Tile resolution
 


### PR DESCRIPTION
I believe there is a typo in the current table of precision values. The README says a few lines after the table:

> All internal math is done in terms of a 32-bit tile coordinate system, so 1/(2^32) of the size of Earth, or about 1cm, is the smallest distinguishable distance. If maxzoom + detail > 32, no additional resolution is obtained than by using a smaller maxzoom or detail, and the detail of tiles will be reduced to the maximum that can be used with the specified maxzoom.

So there shouldn't be a zoom level where the precision is better than 1 cm.