### PR TITLE
Add ".fgb" extension to vector trim list in  main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1390,6 +1390,7 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 				".pmtiles",
 				".csv",
 				".gz",
+			        ".fgb",
 			};
 
 			// Trim .json or .mbtiles from the name


### PR DESCRIPTION
Added the extension ".fgb" to the vector trim list to avoid including the extension in the layer id creation by default, when an mbtiles is generated from several flatgeobuf files.