### PR TITLE
Add tippecanoe-overzoom to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tile-join
 tippecanoe-decode
 tippecanoe-enumerate
 tippecanoe-json-tool
+tippecanoe-overzoom
 unit
 
 # Tests


### PR DESCRIPTION
Small housekeeping: noticed other `bin` programs are in the `.gitignore` but not `tippecanoe-overzoom`