### PR TITLE
Reduce tiling memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.53.0
+
+* Stop trying to add features to the tile after the feature limit is reached
+
 # 2.52.0
 
 * Fix accidental loss (at all zooms) of features that specify an explicit minzoom

--- a/tests/loop/out/-z0_-O200_--cluster-densest-as-needed.json
+++ b/tests/loop/out/-z0_-O200_--cluster-densest-as-needed.json
@@ -9,7 +9,7 @@
 "maxzoom": "0",
 "minzoom": "0",
 "name": "tests/loop/out/-z0_-O200_--cluster-densest-as-needed.json.check.mbtiles",
-"strategies": "[{\"coalesced_as_needed\":999,\"feature_count_desired\":1000}]",
+"strategies": "[{\"coalesced_as_needed\":999,\"feature_count_desired\":201}]",
 "type": "overlay",
 "version": "2"
 }, "features": [

--- a/tests/loop/out/-z0_-O200_--drop-densest-as-needed.json
+++ b/tests/loop/out/-z0_-O200_--drop-densest-as-needed.json
@@ -9,7 +9,7 @@
 "maxzoom": "0",
 "minzoom": "0",
 "name": "tests/loop/out/-z0_-O200_--drop-densest-as-needed.json.check.mbtiles",
-"strategies": "[{\"dropped_as_needed\":999,\"feature_count_desired\":1000}]",
+"strategies": "[{\"dropped_as_needed\":999,\"feature_count_desired\":201}]",
 "type": "overlay",
 "version": "2"
 }, "features": [

--- a/tests/loop/out/-z0_-O200_--drop-fraction-as-needed.json
+++ b/tests/loop/out/-z0_-O200_--drop-fraction-as-needed.json
@@ -9,7 +9,7 @@
 "maxzoom": "0",
 "minzoom": "0",
 "name": "tests/loop/out/-z0_-O200_--drop-fraction-as-needed.json.check.mbtiles",
-"strategies": "[{\"dropped_as_needed\":999,\"feature_count_desired\":1000}]",
+"strategies": "[{\"dropped_as_needed\":999,\"feature_count_desired\":201}]",
 "type": "overlay",
 "version": "2"
 }, "features": [

--- a/tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json
+++ b/tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json
@@ -1,15 +1,15 @@
 { "type": "FeatureCollection", "properties": {
 "antimeridian_adjusted_bounds": "-122.538670,37.705764,-12.240000,37.836443",
 "bounds": "-122.538670,37.705764,-12.240000,37.836443",
-"center": "-122.453613,37.770713,13",
+"center": "-122.497559,37.735967,13",
 "description": "tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json.check.mbtiles",
 "format": "pbf",
 "generator_options": "./tippecanoe -q -a@ -f -o tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json.check.mbtiles -Z11 -z13 -O100 --cluster-densest-as-needed tests/muni/muni.json",
-"json": "{\"vector_layers\":[{\"id\":\"muni\",\"description\":\"\",\"minzoom\":11,\"maxzoom\":13,\"fields\":{\"clustered\":\"Boolean\",\"name\":\"String\",\"point_count\":\"Number\",\"point_count_abbreviated\":\"String\",\"sqrt_point_count\":\"Number\"}},{\"id\":\"subway\",\"description\":\"\",\"minzoom\":11,\"maxzoom\":13,\"fields\":{\"clustered\":\"Boolean\",\"name\":\"String\",\"point_count\":\"Number\",\"point_count_abbreviated\":\"String\",\"sqrt_point_count\":\"Number\"}}],\"tilestats\":{\"layerCount\":2,\"layers\":[{\"layer\":\"muni\",\"count\":4592,\"geometry\":\"Point\",\"attributeCount\":5,\"attributes\":[{\"attribute\":\"clustered\",\"count\":1,\"type\":\"boolean\",\"values\":[true]},{\"attribute\":\"name\",\"count\":1000,\"type\":\"string\",\"values\":[\" 4th St & Brannan St\",\" Conzelman Rd & Mccullough Rd\",\"100 O'Shaughnessy Blvd\",\"101 Dakota St\",\"1095 CONNECTICUT ST\",\"10th Ave & Ortega St\",\"10th Ave & Pacheco St\",\"10th Ave & Quintara St\",\"1100 Lake Merced Blvd\",\"115 TELEGRAPH Hill Blvd\",\"117 Warren Dr\",\"11th St & Bryant St\",\"11th St & Folsom St\",\"11th St & Harrison St\",\"11th St & Howard St\",\"11th St & Market St\",\"11th St & Mission St\",\"11th St/btw Market & Mission\",\"120 Portola Dr\",\"126 Miraloma Dr\",\"13th St & Gateview Ave\",\"14 Dakota St\",\"14th  Avenue & Geary Boulevard\",\"14th Ave & Quintara St\",\"14th Ave & Santiago St\",\"14th Ave & Taraval St\",\"14th Ave & Ulloa St\",\"14th St & Alpine Ter\",\"14th St & Castro St\",\"14th St & Church St\",\"14th St & Mission St\",\"14th St & Noe St\",\"14th St & SANCHEZ ST\",\"14th St & Sanchez St\",\"150 Otis St\",\"15th Ave & Noriega St\",\"15th Ave & Ortega St\",\"15th Ave & Pacheco St\",\"15th Ave & Quintara St\",\"15th Ave & Taraval St\",\"15th Ave & Ulloa St\",\"15th Ave & West Portal Ave\",\"15th St & Mission St\",\"16 th St & South Van Ness\",\"164 Addison  St\",\"1650 Geneva Ave\",\"1697 7th Ave\",\"16th Ave & Lawton St\",\"16th Ave & Lomita Ave\",\"16th Ave & Moraga St\",\"16th Ave & Noriega St\",\"16th Ave & Ortega St\",\"16th Ave & Pacheco St\",\"16th Avenue at Lawton Street\",\"16th St & 4th St\",\"16th St & Bryant St\",\"16th St & Church St\",\"16th St & Dolores St\",\"16th St & Folsom St\",\"16th St & Guerrero St\",\"16th St & Harrison St\",\"16th St & Kansas St\",\"16th St & Mission St\",\"16th St & Missouri St\",\"16th St & Potrero Ave\",\"16th St & San Bruno Ave\",\"16th St & Shotwell St\",\"16th St & South Van Ness\",\"16th St & Valencia St\",\"16th St & Vermont St\",\"16th St & Wisconsin St\",\"16th St& Rhode Island St\",\"16th Street & 4th Street\",\"16th Street & Missouri St\",\"16th Street & Rhode Islandi St\",\"16th Street & Wisconsin St\",\"170 Buckingham Way\",\"1701 Geneva Ave\",\"1721 Geneva Ave\",\"1725 Sunnydale Ave\",\"1730 3rd St\",\"1731 3RD ST\",\"1750 Geneva Ave\",\"176 Rhode Island St\",\"1798 Laguna Honda Blvd\",\"17TH ST & KANSAS ST\",\"17th Ave & Quintara St\",\"17th Ave & Rivera St\",\"17th Ave & Santiago St\",\"17th St & Belvedere St\",\"17th St & Castro St\",\"17th St & Clayton St\",\"17th St & Cole St\",\"17th St & De Haro St\",\"17th St & Diamond St\",\"17th St & Kansas St\",\"17th St & Noe St\",\"17th St & Wisconsin St\",\"1800 Sunnydale Ave\",\"18th St & 3rd St\"]},{\"attribute\":\"point_count\",\"count\":33,\"type\":\"number\",\"values\":[10,11,12,13,14,15,16,17,18,19,2,20,21,22,23,24,25,26,27,29,3,30,32,37,38,4,40,46,5,6,7,8,9],\"min\":2,\"max\":46},{\"attribute\":\"point_count_abbreviated\",\"count\":33,\"type\":\"string\",\"values\":[\"10\",\"11\",\"12\",\"13\",\"14\",\"15\",\"16\",\"17\",\"18\",\"19\",\"2\",\"20\",\"21\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"29\",\"3\",\"30\",\"32\",\"37\",\"38\",\"4\",\"40\",\"46\",\"5\",\"6\",\"7\",\"8\",\"9\"]},{\"attribute\":\"sqrt_point_count\",\"count\":33,\"type\":\"number\",\"values\":[1.410000,1.730000,2.000000,2.240000,2.450000,2.650000,2.830000,3.000000,3.160000,3.320000,3.460000,3.610000,3.740000,3.870000,4.000000,4.120000,4.240000,4.360000,4.470000,4.580000,4.690000,4.800000,4.900000,5.000000,5.100000,5.200000,5.390000,5.480000,5.660000,6.080000,6.160000,6.320000,6.780000],\"min\":1.41,\"max\":6.78}]},{\"layer\":\"subway\",\"count\":19,\"geometry\":\"Point\",\"attributeCount\":5,\"attributes\":[{\"attribute\":\"clustered\",\"count\":1,\"type\":\"boolean\",\"values\":[true]},{\"attribute\":\"name\",\"count\":18,\"type\":\"string\",\"values\":[\"Metro Castro Station/Downtown\",\"Metro Castro Station/Outbound\",\"Metro Church Station/Downtown\",\"Metro Church Station/Outbound\",\"Metro Civic Center Station/Downtn\",\"Metro Civic Center Station/Downtown\",\"Metro Civic Center Station/Outbd\",\"Metro Embarcadero Station\",\"Metro Embarcadero Station/Downtown\",\"Metro Forest Hill Station/Downtown\",\"Metro Montgomery Station/Downtown\",\"Metro Montgomery Station/Outbound\",\"Metro Powell Station/Downtown\",\"Metro Powell Station/Outbound\",\"Metro Van Ness Station\",\"Metro Van Ness Station/Downtown\",\"Metro Van Ness Station/Outbound\",\"Van Ness Station Outbound\"]},{\"attribute\":\"point_count\",\"count\":5,\"type\":\"number\",\"values\":[12,2,3,5,7],\"min\":2,\"max\":12},{\"attribute\":\"point_count_abbreviated\",\"count\":5,\"type\":\"string\",\"values\":[\"12\",\"2\",\"3\",\"5\",\"7\"]},{\"attribute\":\"sqrt_point_count\",\"count\":5,\"type\":\"number\",\"values\":[1.410000,1.730000,2.240000,2.650000,3.460000],\"min\":1.41,\"max\":3.46}]}]}}",
+"json": "{\"vector_layers\":[{\"id\":\"muni\",\"description\":\"\",\"minzoom\":11,\"maxzoom\":13,\"fields\":{\"clustered\":\"Boolean\",\"name\":\"String\",\"point_count\":\"Number\",\"point_count_abbreviated\":\"String\",\"sqrt_point_count\":\"Number\"}},{\"id\":\"subway\",\"description\":\"\",\"minzoom\":11,\"maxzoom\":13,\"fields\":{\"clustered\":\"Boolean\",\"name\":\"String\",\"point_count\":\"Number\",\"point_count_abbreviated\":\"String\",\"sqrt_point_count\":\"Number\"}}],\"tilestats\":{\"layerCount\":2,\"layers\":[{\"layer\":\"muni\",\"count\":4592,\"geometry\":\"Point\",\"attributeCount\":5,\"attributes\":[{\"attribute\":\"clustered\",\"count\":1,\"type\":\"boolean\",\"values\":[true]},{\"attribute\":\"name\",\"count\":1000,\"type\":\"string\",\"values\":[\" 4th St & Brannan St\",\" Conzelman Rd & Mccullough Rd\",\"100 O'Shaughnessy Blvd\",\"101 Dakota St\",\"1095 CONNECTICUT ST\",\"10th Ave & Ortega St\",\"10th Ave & Pacheco St\",\"10th Ave & Quintara St\",\"1100 Lake Merced Blvd\",\"115 TELEGRAPH Hill Blvd\",\"117 Warren Dr\",\"11th St & Bryant St\",\"11th St & Folsom St\",\"11th St & Harrison St\",\"11th St & Howard St\",\"11th St & Market St\",\"11th St & Mission St\",\"11th St/btw Market & Mission\",\"120 Portola Dr\",\"126 Miraloma Dr\",\"13th St & Gateview Ave\",\"14 Dakota St\",\"14th  Avenue & Geary Boulevard\",\"14th Ave & Quintara St\",\"14th Ave & Santiago St\",\"14th Ave & Taraval St\",\"14th Ave & Ulloa St\",\"14th St & Alpine Ter\",\"14th St & Castro St\",\"14th St & Church St\",\"14th St & Mission St\",\"14th St & Noe St\",\"14th St & SANCHEZ ST\",\"14th St & Sanchez St\",\"150 Otis St\",\"15th Ave & Noriega St\",\"15th Ave & Ortega St\",\"15th Ave & Pacheco St\",\"15th Ave & Quintara St\",\"15th Ave & Taraval St\",\"15th Ave & Ulloa St\",\"15th Ave & West Portal Ave\",\"15th St & Mission St\",\"16 th St & South Van Ness\",\"164 Addison  St\",\"1650 Geneva Ave\",\"1697 7th Ave\",\"16th Ave & Lawton St\",\"16th Ave & Lomita Ave\",\"16th Ave & Moraga St\",\"16th Ave & Noriega St\",\"16th Ave & Ortega St\",\"16th Ave & Pacheco St\",\"16th Avenue at Lawton Street\",\"16th St & 4th St\",\"16th St & Bryant St\",\"16th St & Church St\",\"16th St & Dolores St\",\"16th St & Folsom St\",\"16th St & Guerrero St\",\"16th St & Harrison St\",\"16th St & Kansas St\",\"16th St & Mission St\",\"16th St & Missouri St\",\"16th St & Potrero Ave\",\"16th St & San Bruno Ave\",\"16th St & Shotwell St\",\"16th St & South Van Ness\",\"16th St & Valencia St\",\"16th St & Vermont St\",\"16th St & Wisconsin St\",\"16th St& Rhode Island St\",\"16th Street & 4th Street\",\"16th Street & Missouri St\",\"16th Street & Rhode Islandi St\",\"16th Street & Wisconsin St\",\"170 Buckingham Way\",\"1701 Geneva Ave\",\"1721 Geneva Ave\",\"1725 Sunnydale Ave\",\"1730 3rd St\",\"1731 3RD ST\",\"1750 Geneva Ave\",\"176 Rhode Island St\",\"1798 Laguna Honda Blvd\",\"17TH ST & KANSAS ST\",\"17th Ave & Quintara St\",\"17th Ave & Rivera St\",\"17th Ave & Santiago St\",\"17th St & Belvedere St\",\"17th St & Castro St\",\"17th St & Clayton St\",\"17th St & Cole St\",\"17th St & De Haro St\",\"17th St & Diamond St\",\"17th St & Kansas St\",\"17th St & Noe St\",\"17th St & Wisconsin St\",\"1800 Sunnydale Ave\",\"18th St & 3rd St\"]},{\"attribute\":\"point_count\",\"count\":144,\"type\":\"number\",\"values\":[10,105,106,109,11,114,115,118,119,12,128,13,138,14,142,144,147,15,150,151,152,155,156,16,162,167,17,170,171,18,180,182,183,184,186,19,190,194,195,2,20,201,202,203,204,21,210,213,214,217,22,222,223,224,228,23,230,231,233,234,237,238,239,24,240,241,245,247,248,25,250,251,252,256,257,258,259,26,260,264,265,267,268,27,276,277,28,282,29,295,3,30,304,310,314,318,32,329,33,331],\"min\":2,\"max\":391},{\"attribute\":\"point_count_abbreviated\",\"count\":144,\"type\":\"string\",\"values\":[\"10\",\"105\",\"106\",\"109\",\"11\",\"114\",\"115\",\"118\",\"119\",\"12\",\"128\",\"13\",\"138\",\"14\",\"142\",\"144\",\"147\",\"15\",\"150\",\"151\",\"152\",\"155\",\"156\",\"16\",\"162\",\"167\",\"17\",\"170\",\"171\",\"18\",\"180\",\"182\",\"183\",\"184\",\"186\",\"19\",\"190\",\"194\",\"195\",\"2\",\"20\",\"201\",\"202\",\"203\",\"204\",\"21\",\"210\",\"213\",\"214\",\"217\",\"22\",\"222\",\"223\",\"224\",\"228\",\"23\",\"230\",\"231\",\"233\",\"234\",\"237\",\"238\",\"239\",\"24\",\"240\",\"241\",\"245\",\"247\",\"248\",\"25\",\"250\",\"251\",\"252\",\"256\",\"257\",\"258\",\"259\",\"26\",\"260\",\"264\",\"265\",\"267\",\"268\",\"27\",\"276\",\"277\",\"28\",\"282\",\"29\",\"295\",\"3\",\"30\",\"304\",\"310\",\"314\",\"318\",\"32\",\"329\",\"33\",\"331\"]},{\"attribute\":\"sqrt_point_count\",\"count\":144,\"type\":\"number\",\"values\":[1.410000,1.730000,10.250000,10.300000,10.440000,10.680000,10.720000,10.860000,10.910000,11.310000,11.750000,11.920000,12.000000,12.120000,12.250000,12.290000,12.330000,12.450000,12.490000,12.730000,12.920000,13.040000,13.080000,13.420000,13.490000,13.530000,13.560000,13.640000,13.780000,13.930000,13.960000,14.180000,14.210000,14.250000,14.280000,14.490000,14.590000,14.630000,14.730000,14.900000,14.930000,14.970000,15.100000,15.170000,15.200000,15.260000,15.300000,15.390000,15.430000,15.460000,15.490000,15.520000,15.650000,15.720000,15.750000,15.810000,15.840000,15.870000,16.000000,16.030000,16.060000,16.090000,16.120000,16.250000,16.280000,16.340000,16.370000,16.610000,16.640000,16.790000,17.180000,17.440000,17.610000,17.720000,17.830000,18.140000,18.190000,18.280000,18.550000,18.570000,18.680000,18.710000,18.840000,19.340000,19.360000,19.770000,2.000000,2.240000,2.450000,2.650000,2.830000,3.000000,3.160000,3.320000,3.460000,3.610000,3.740000,3.870000,4.000000,4.120000],\"min\":1.41,\"max\":19.77}]},{\"layer\":\"subway\",\"count\":19,\"geometry\":\"Point\",\"attributeCount\":5,\"attributes\":[{\"attribute\":\"clustered\",\"count\":1,\"type\":\"boolean\",\"values\":[true]},{\"attribute\":\"name\",\"count\":18,\"type\":\"string\",\"values\":[\"Metro Castro Station/Downtown\",\"Metro Castro Station/Outbound\",\"Metro Church Station/Downtown\",\"Metro Church Station/Outbound\",\"Metro Civic Center Station/Downtn\",\"Metro Civic Center Station/Downtown\",\"Metro Civic Center Station/Outbd\",\"Metro Embarcadero Station\",\"Metro Embarcadero Station/Downtown\",\"Metro Forest Hill Station/Downtown\",\"Metro Montgomery Station/Downtown\",\"Metro Montgomery Station/Outbound\",\"Metro Powell Station/Downtown\",\"Metro Powell Station/Outbound\",\"Metro Van Ness Station\",\"Metro Van Ness Station/Downtown\",\"Metro Van Ness Station/Outbound\",\"Van Ness Station Outbound\"]},{\"attribute\":\"point_count\",\"count\":10,\"type\":\"number\",\"values\":[10,11,12,2,3,4,5,6,7,8],\"min\":2,\"max\":12},{\"attribute\":\"point_count_abbreviated\",\"count\":10,\"type\":\"string\",\"values\":[\"10\",\"11\",\"12\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\"]},{\"attribute\":\"sqrt_point_count\",\"count\":10,\"type\":\"number\",\"values\":[1.410000,1.730000,2.000000,2.240000,2.450000,2.650000,2.830000,3.160000,3.320000,3.460000],\"min\":1.41,\"max\":3.46}]}]}}",
 "maxzoom": "13",
 "minzoom": "11",
 "name": "tests/muni/out/-Z11_-z13_-O100_--cluster-densest-as-needed.json.check.mbtiles",
-"strategies": "[{},{},{},{},{},{},{},{},{},{},{},{\"dropped_by_rate\":4080,\"coalesced_as_needed\":662,\"feature_count_desired\":687},{\"dropped_by_rate\":2974,\"coalesced_as_needed\":1747,\"feature_count_desired\":755},{\"coalesced_as_needed\":4344,\"feature_count_desired\":856}]",
+"strategies": "[{},{},{},{},{},{},{},{},{},{},{},{\"dropped_by_rate\":4080,\"coalesced_as_needed\":656,\"feature_count_desired\":101},{\"dropped_by_rate\":2974,\"coalesced_as_needed\":1735,\"feature_count_desired\":101},{\"coalesced_as_needed\":4301,\"feature_count_desired\":101}]",
 "type": "overlay",
 "version": "2"
 }, "features": [
@@ -45,9 +45,9 @@
 ,
 { "type": "Feature", "properties": { "name": "19th Ave & Junipero Serra Blvd", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.470694, 37.714007 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Daly City BART West Station Rd.", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.459149, 37.711359 ] } }
+{ "type": "Feature", "properties": { "name": "Daly City BART West Station Rd.", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.459879, 37.711529 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & GoeThe St" }, "geometry": { "type": "Point", "coordinates": [ -122.457089, 37.707353 ] } }
+{ "type": "Feature", "properties": { "name": "Sickles Ave & Alemany Blvd", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.455931, 37.708813 ] } }
 ,
 { "type": "Feature", "properties": { "name": "San Jose Ave & Lakeview Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.449622, 37.713396 ] } }
 ,
@@ -81,29 +81,29 @@
 ,
 { "type": "Feature", "properties": { "name": "Montgomery St & Moraga Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.456617, 37.800527 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "LETTERMAN DR/Tides Bldg", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.446017, 37.799103 ] } }
+{ "type": "Feature", "properties": { "name": "LETTERMAN DR/Tides Bldg", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.445760, 37.800493 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Jackson St & Baker St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.437177, 37.798628 ] } }
+{ "type": "Feature", "properties": { "name": "Presidio Ave & Jackson St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.437820, 37.798696 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Steiner St & Green St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.434645, 37.791812 ] } }
+{ "type": "Feature", "properties": { "name": "Divisadero St & Clay St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.435503, 37.791541 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Point Lobos Ave & Merrie Way", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.506914, 37.779399 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Balboa St & 43rd Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.501936, 37.773598 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah/La Playa/Ocean Beach", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.507300, 37.759960 ] } }
+{ "type": "Feature", "properties": { "name": "Judah/La Playa/Ocean Beach", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.508759, 37.760334 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & 43rd Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.493396, 37.777838 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 46th Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.502751, 37.764812 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 35th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.487559, 37.778822 ] } }
+{ "type": "Feature", "properties": { "name": "32nd Ave & Clement St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.491722, 37.778517 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 20th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.480779, 37.776481 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton S t& 30th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.483611, 37.780382 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lincoln Way & 35th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.492237, 37.759791 ] } }
+{ "type": "Feature", "properties": { "name": "25th Ave & Fulton St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.483354, 37.771732 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lincoln Way & 27th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.480950, 37.761521 ] } }
+{ "type": "Feature", "properties": { "name": "Lincoln Way & 29th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.490778, 37.759859 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 23rd Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.478590, 37.754057 ] } }
+{ "type": "Feature", "properties": { "name": "22nd Ave & Lincoln Way", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.479963, 37.759655 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Noriega St & 46th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.503524, 37.746625 ] } }
 ,
@@ -111,69 +111,77 @@
 ,
 { "type": "Feature", "properties": { "name": "Sloat Blvd & 47th Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.502151, 37.734815 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "John Muir Dr & Skyline Blvd", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.494297, 37.742417 ] } }
+{ "type": "Feature", "properties": { "name": "John Muir Dr & Skyline Blvd", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.494297, 37.742960 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "30th Ave & Taraval St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.482753, 37.745200 ] } }
+{ "type": "Feature", "properties": { "name": "Sunset Blvd & Vicente St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.485929, 37.744148 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Taraval St & 23rd Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.491035, 37.735256 ] } }
+{ "type": "Feature", "properties": { "name": "19th Ave & Rivera St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.487774, 37.738582 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sloat Blvd & 26th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.480092, 37.727484 ] } }
+{ "type": "Feature", "properties": { "name": "Sloat Blvd & Everglade Dr" }, "geometry": { "type": "Point", "coordinates": [ -122.489662, 37.733967 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "90 Buckingham Way", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.471981, 37.767594 ] } }
+{ "type": "Feature", "properties": { "name": "Sloat Blvd & 26th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.480693, 37.727789 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 14th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.465372, 37.779568 ] } }
+{ "type": "Feature", "properties": { "name": "91 Buckingham Way", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.472539, 37.762980 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Arguello Blvd & Euclid Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.459192, 37.777024 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 14th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.467518, 37.778211 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lincoln Way & Funston Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.469234, 37.761521 ] } }
+{ "type": "Feature", "properties": { "name": "California St & Cherry St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.459235, 37.779263 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lincoln Way & 7th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.461510, 37.761250 ] } }
+{ "type": "Feature", "properties": { "name": "Stanyan St & Hayes St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.466874, 37.765083 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Euclid Ave & Iris Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.447991, 37.781535 ] } }
+{ "type": "Feature", "properties": { "name": "16th Ave & Noriega St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.466402, 37.760605 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Turk St & Central Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.440095, 37.779907 ] } }
+{ "type": "Feature", "properties": { "name": "Irving St & 2nd Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.459149, 37.763557 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "McAllister St & Divisadero St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.444386, 37.770613 ] } }
+{ "type": "Feature", "properties": { "name": "Euclid Ave & Collins St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.447562, 37.781264 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Frederick St & Masonic St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.445116, 37.761521 ] } }
+{ "type": "Feature", "properties": { "name": "Turk St & Central Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.439923, 37.779941 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Roosevelt Way & 15th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.441597, 37.760503 ] } }
+{ "type": "Feature", "properties": { "name": "Turk St & Baker St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.442927, 37.772716 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "15th Ave & Quintara St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.468891, 37.743368 ] } }
+{ "type": "Feature", "properties": { "name": "Cole St & Carl St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.446146, 37.763658 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Laguna Honda Blvd & Clarendon Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.457905, 37.746761 ] } }
+{ "type": "Feature", "properties": { "name": "Corbett Ave & Romain St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.439451, 37.760978 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Portola Dr & Del Sur Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.470393, 37.732813 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & 16th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.470522, 37.745641 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "19th Ave & Holloway Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.467775, 37.725447 ] } }
+{ "type": "Feature", "properties": { "name": "West Portal Ave & Ulloa St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.461252, 37.745030 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Monterey Blvd & Plymouth Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.457776, 37.723750 ] } }
+{ "type": "Feature", "properties": { "name": "Portola Dr & San Pablo Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.467904, 37.735698 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Portola Dr & Woodside Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.447433, 37.745302 ] } }
+{ "type": "Feature", "properties": { "name": "Ocean Ave & Aptos Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.469835, 37.725142 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "O'Shaughnessy Blvd & Malta Dr", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.437477, 37.746524 ] } }
+{ "type": "Feature", "properties": { "name": "Plymouth Ave & Yerba Buena Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.458377, 37.725583 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Diamond St & Diamond Heights Blvd", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.443485, 37.734951 ] } }
+{ "type": "Feature", "properties": { "name": "Grafton Ave & Lee St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.447605, 37.744521 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "PHELAN AVE/CCSF (South Entrance)", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.446961, 37.722358 ] } }
+{ "type": "Feature", "properties": { "name": "Reposa Way & Myra Way", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.441339, 37.745166 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Diamond St & Chenery St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.435331, 37.727178 ] } }
+{ "type": "Feature", "properties": { "name": "Diamond St & 26th St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.435460, 37.741671 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Teresita Blvd & Foerster St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.450137, 37.727450 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Geneva Ave/Balboa Park BART", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.442412, 37.725108 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Ocean Ave & Cayuga Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.435117, 37.724022 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Larkin St & Beach St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.421298, 37.806054 ] } }
 ,
 { "type": "Feature", "properties": { "name": "North Point St & Jones St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.421727, 37.804020 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Polk St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.421985, 37.795949 ] } }
+{ "type": "Feature", "properties": { "name": "Union St & Polk St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.422242, 37.795848 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Taylor St & Bay St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.414947, 37.795441 ] } }
+{ "type": "Feature", "properties": { "name": "Hyde St & Vallejo St", "clustered": true, "point_count": 20, "sqrt_point_count": 4.47, "point_count_abbreviated": "20" }, "geometry": { "type": "Point", "coordinates": [ -122.415204, 37.796085 ] } }
+,
+{ "type": "Feature", "properties": { "name": "California St & Jones St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.413874, 37.789981 ] } }
 ,
 { "type": "Feature", "properties": { "name": "The Embarcadero & Grant St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.407393, 37.807411 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Stockton St & Greenwich St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.405891, 37.796729 ] } }
+{ "type": "Feature", "properties": { "name": "Stockton St & Greenwich St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.406106, 37.796763 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & Montgomery St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.400227, 37.792762 ] } }
+{ "type": "Feature", "properties": { "name": "Washington St & Sansome St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.400956, 37.792829 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & Davis St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.393918, 37.792049 ] } }
+{ "type": "Feature", "properties": { "name": "Clay St & Drumm St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.394304, 37.792253 ] } }
 ,
 { "type": "Feature", "properties": { "name": "13th St & Gateview Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.371945, 37.825718 ] } }
 ,
@@ -183,43 +191,47 @@
 ,
 { "type": "Feature", "properties": { "name": "Sutter St & Laguna St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.427049, 37.780348 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hayes St & Gough St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.417264, 37.781332 ] } }
+{ "type": "Feature", "properties": { "name": "Hayes St & Gough St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.417092, 37.782180 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 9th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.422457, 37.771529 ] } }
+{ "type": "Feature", "properties": { "name": "Van Ness Ave & Oak St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.421684, 37.772411 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Valencia St & 15th St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.424302, 37.760334 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Folsom St & 14th St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.415805, 37.763048 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 22nd St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.406363, 37.781569 ] } }
+{ "type": "Feature", "properties": { "name": "Folsom St & 22nd St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.406363, 37.781976 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bryant St & 9th St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.398810, 37.779602 ] } }
+{ "type": "Feature", "properties": { "name": "7th St & Harrison St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.399626, 37.779161 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "2nd St & Townsend St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.397008, 37.775091 ] } }
+{ "type": "Feature", "properties": { "name": "2nd St & Townsend St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.395849, 37.776074 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Vermont St & 17th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.403960, 37.760808 ] } }
+{ "type": "Feature", "properties": { "name": "Potrero Ave & 16th St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.404776, 37.762369 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "22nd St & Wisconsin St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.394390, 37.761996 ] } }
+{ "type": "Feature", "properties": { "name": "Southern Heights Ave & De Haro St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.395678, 37.762098 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "22nd St & Mississippi St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.404132, 37.755007 ] } }
+{ "type": "Feature", "properties": { "name": "Missouri St & Sierra St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.399926, 37.755583 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noe St & 29th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.423658, 37.743571 ] } }
+{ "type": "Feature", "properties": { "name": "24th St & Dolores St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.426105, 37.741569 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 24th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.413144, 37.745098 ] } }
+{ "type": "Feature", "properties": { "name": "24th St & Valencia St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.416105, 37.748763 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bosworth St & Rotteck St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.428293, 37.727246 ] } }
+{ "type": "Feature", "properties": { "name": "Ripley St & Alabama St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.421856, 37.734849 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Avalon Ave & La Grande Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.418895, 37.728808 ] } }
+{ "type": "Feature", "properties": { "name": "Athens St & Excelsior Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.422929, 37.725719 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Felton St & Amherst St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.409797, 37.740076 ] } }
+{ "type": "Feature", "properties": { "name": "Crescent Ave & Putnam St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.414861, 37.727111 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bradford St & Esmeralda Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.401471, 37.745098 ] } }
+{ "type": "Feature", "properties": { "name": "24th St & Bryant St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.406793, 37.747168 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Jerrold Ave & Selby St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.395163, 37.737768 ] } }
+{ "type": "Feature", "properties": { "name": "Oakdale Ave & Barneveld Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.398553, 37.746931 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Silver Ave&Santa Fe Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.404261, 37.725413 ] } }
+{ "type": "Feature", "properties": { "name": "Jerrold Ave & Selby St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.394261, 37.738650 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Topeka Ave & Venus St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.392759, 37.729113 ] } }
+{ "type": "Feature", "properties": { "name": "Girard ST & Burrows ST", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.404647, 37.726092 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Mansell St & San Bruno Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.392716, 37.730878 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Salinas Ave & Gould St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.394948, 37.722392 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Not a public stop", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.386794, 37.755380 ] } }
 ,
@@ -275,7 +287,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Lake Merced Blvd & Higuera Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.479770, 37.719032 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Gonzalez Dr. & Crespi Dr.", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.470973, 37.719558 ] } }
+{ "type": "Feature", "properties": { "name": "Gonzalez Dr. & Crespi Dr.", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.472067, 37.719558 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Garfield St & Victoria St" }, "geometry": { "type": "Point", "coordinates": [ -122.465436, 37.719609 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Garfield St & Bright St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.459836, 37.719829 ] } }
 ,
@@ -291,11 +305,13 @@
 ,
 { "type": "Feature", "properties": { "name": "Randolph St & Arch St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.466788, 37.712632 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Daly City BART West Station Rd.", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.466123, 37.710646 ] } }
+{ "type": "Feature", "properties": { "name": "Daly City BART West Station Rd." }, "geometry": { "type": "Point", "coordinates": [ -122.468655, 37.707047 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sagamore St & Orizaba Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.457197, 37.713193 ] } }
+{ "type": "Feature", "properties": { "name": "Randolph St & Bright St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.458227, 37.713855 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & San Jose Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.459149, 37.706691 ] } }
+{ "type": "Feature", "properties": { "name": "Plymouth Ave & Sagamore St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.457433, 37.709254 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Mission St & GoeThe St" }, "geometry": { "type": "Point", "coordinates": [ -122.457068, 37.707353 ] } }
 ,
 { "type": "Feature", "properties": { "name": "San Jose Ave & Mt Vernon Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.449386, 37.714788 ] } }
 ,
@@ -321,9 +337,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Point Lobos Ave & El Camino Del Mar", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.510970, 37.779466 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & La Playa St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.509017, 37.775973 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & La Playa St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.509704, 37.774751 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "V.A. HOSPITAL", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.503459, 37.780620 ] } }
+{ "type": "Feature", "properties": { "name": "V.A. Hospital", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.503803, 37.780874 ] } }
 ,
 { "type": "Feature", "properties": { "name": "45th Ave & Balboa St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.503974, 37.774209 ] } }
 ,
@@ -331,35 +347,39 @@
 ,
 { "type": "Feature", "properties": { "name": "GREAT HWY/near Beach Chalet", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.509918, 37.765897 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah/La Playa/Ocean Beach", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.507536, 37.762844 ] } }
+{ "type": "Feature", "properties": { "name": "Judah/La Playa/Ocean Beach", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.508245, 37.762267 ] } }
+,
+{ "type": "Feature", "properties": { "name": "46th Ave & Lincoln Way" }, "geometry": { "type": "Point", "coordinates": [ -122.506099, 37.764032 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Judah St & 48th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.504683, 37.759367 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & 36th Ave", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.491572, 37.780976 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 36th Ave", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.491851, 37.781044 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 37th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.492945, 37.775396 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 28th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.492967, 37.775820 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton S t& 30th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.485135, 37.780230 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 28th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.485886, 37.779721 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 19th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.480865, 37.779348 ] } }
+{ "type": "Feature", "properties": { "name": "Clement St & 22nd Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.480006, 37.781366 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "25th Ave & Fulton St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.480242, 37.773819 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 25th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.482474, 37.775125 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "36th Ave & Lincoln Way", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.492580, 37.764761 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & 22nd Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.485135, 37.769510 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & Sunset Blvd", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.493546, 37.758366 ] } }
+{ "type": "Feature", "properties": { "name": "Lincoln Way & 33rd Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.494061, 37.759723 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 33rd Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.486401, 37.760537 ] } }
+{ "type": "Feature", "properties": { "name": "Noriega St & 34th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.489984, 37.756618 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "22nd Ave & Lincoln Way", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.480307, 37.762624 ] } }
+{ "type": "Feature", "properties": { "name": "Lincoln Way & 27th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.480049, 37.765270 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 25th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.478654, 37.757840 ] } }
+{ "type": "Feature", "properties": { "name": "19th Ave & Irving St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.482152, 37.759350 ] } }
+,
+{ "type": "Feature", "properties": { "name": "22nd Ave & Lawton St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.478032, 37.757891 ] } }
 ,
 { "type": "Feature", "properties": { "name": "47th Ave & Noriega St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.504253, 37.750104 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Quintara St & 41st Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.502923, 37.741603 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & 41st Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.502966, 37.741586 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Taraval St & 42nd Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.499125, 37.742061 ] } }
+{ "type": "Feature", "properties": { "name": "Taraval St & 44th Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.500284, 37.741976 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Sloat Blvd & 47th Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.502108, 37.735070 ] } }
 ,
@@ -371,105 +391,109 @@
 ,
 { "type": "Feature", "properties": { "name": "Sunset Blvd & Wawona St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.489212, 37.740941 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Quintara St & 28th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.480156, 37.749306 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & 28th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.480886, 37.749408 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "19th Ave & Rivera St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.479813, 37.743826 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & 19th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.479384, 37.744793 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "19th Ave & Taraval St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.492130, 37.734900 ] } }
+{ "type": "Feature", "properties": { "name": "Taraval St & 22nd Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.489963, 37.736478 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sunset Blvd & Lake Merced Blvd", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.491658, 37.731879 ] } }
+{ "type": "Feature", "properties": { "name": "Sunset Blvd & Ocean Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.492323, 37.731862 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Sloat Blvd & El Mirasol Pl", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.481959, 37.734459 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Buckingham Way & Winston Dr", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.481294, 37.724701 ] } }
+{ "type": "Feature", "properties": { "name": "Buckingham Way & Winston Dr", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.481422, 37.724463 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "91 Buckingham Way", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.475114, 37.750629 ] } }
+{ "type": "Feature", "properties": { "name": "280 Buckingham Way", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.477152, 37.730980 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 12th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.468741, 37.782621 ] } }
+{ "type": "Feature", "properties": { "name": "Park Presidio & California Street", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.470479, 37.783130 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 14th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.470114, 37.775583 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 9th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.470114, 37.777821 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "8th Ave & Cabrillo St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.462647, 37.782061 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 10th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.465436, 37.778483 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Euclid Ave & Jordan Ave", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.460051, 37.779958 ] } }
+{ "type": "Feature", "properties": { "name": "6th Ave & Clement St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.459686, 37.783164 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & Arguello Blvd", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.456274, 37.775277 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & Commonwealth St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.461660, 37.776719 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lincoln Way & 17th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.468913, 37.766372 ] } }
+{ "type": "Feature", "properties": { "name": "Turk St & Stanyan St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.458634, 37.773005 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Irving St & 9th Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.470114, 37.760181 ] } }
+{ "type": "Feature", "properties": { "name": "Lincoln Way & 15th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.467990, 37.766474 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "9th Ave & Kirkham St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.464814, 37.761148 ] } }
+{ "type": "Feature", "properties": { "name": "Irving St & 9th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.470307, 37.760334 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & 6th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.458870, 37.763862 ] } }
+{ "type": "Feature", "properties": { "name": "Lawton St & 11th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.465909, 37.759672 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Lincoln Way & 5th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.459643, 37.763930 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Lawton St & 7th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.462776, 37.756262 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Oakpark Dr & Forest Knolls Dr", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.449493, 37.783045 ] } }
+{ "type": "Feature", "properties": { "name": "Oakpark Dr & Forest Knolls Dr", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.450116, 37.782672 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & Baker St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.448592, 37.779432 ] } }
+{ "type": "Feature", "properties": { "name": "Euclid Ave & Presidio Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.446897, 37.782146 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hayes St & Cole St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.445438, 37.776651 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton Street & Shrader Street", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.447197, 37.775701 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Divisadero St & Sutter St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.437220, 37.783791 ] } }
+{ "type": "Feature", "properties": { "name": "Hayes St & Lyon St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.439387, 37.782417 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Eddy St & Pierce St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.437928, 37.777448 ] } }
+{ "type": "Feature", "properties": { "name": "Fillmore St & Pine St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.436469, 37.780823 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mcallister St & Pierce St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.441983, 37.772258 ] } }
+{ "type": "Feature", "properties": { "name": "Haight St & Buena Vista East Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.435997, 37.774497 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Carl St & Stanyan St", "clustered": true, "point_count": 20, "sqrt_point_count": 4.47, "point_count_abbreviated": "20" }, "geometry": { "type": "Point", "coordinates": [ -122.447562, 37.766559 ] } }
+{ "type": "Feature", "properties": { "name": "Shrader St & Haight St", "clustered": true, "point_count": 20, "sqrt_point_count": 4.47, "point_count_abbreviated": "20" }, "geometry": { "type": "Point", "coordinates": [ -122.449107, 37.767594 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Roosevelt Way & Lower Ter", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.446210, 37.760486 ] } }
+{ "type": "Feature", "properties": { "name": "Frederick St & Masonic St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.446253, 37.763506 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "210 Corbett Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.441618, 37.761216 ] } }
+{ "type": "Feature", "properties": { "name": "Carmel St & Belvedere St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.444623, 37.759078 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "17th St & Diamond St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.436383, 37.762369 ] } }
+{ "type": "Feature", "properties": { "name": "BUENA VISTA TER & BUENA VISTA AVE E", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.436168, 37.767136 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "18th St & Castro St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.445223, 37.756652 ] } }
+{ "type": "Feature", "properties": { "name": "Castro St & 16th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.437241, 37.759960 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Quintara St & 17th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.469707, 37.748882 ] } }
+{ "type": "Feature", "properties": { "name": "18th St & Castro St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.439945, 37.758111 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Taraval St & 17th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.470908, 37.741179 ] } }
+{ "type": "Feature", "properties": { "name": "15th Ave & Pacheco St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.470157, 37.749052 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "West Portal Ave & Ulloa St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.465973, 37.741077 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & Cragmont Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.471702, 37.742129 ] } }
+,
+{ "type": "Feature", "properties": { "name": "14th Ave & Ulloa St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.466295, 37.741111 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Clarendon Ave & Clarendon Woods S", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.457154, 37.748135 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Portola Dr & San Pablo Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.458506, 37.741094 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Myra Way & Dalewood Way", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.471144, 37.733271 ] } }
+{ "type": "Feature", "properties": { "name": "Myra Way & Dalewood Way", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.471445, 37.733186 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Monterey Blvd & San Anselmo Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.473118, 37.724005 ] } }
+{ "type": "Feature", "properties": { "name": "Saint Francis Blvd & Santa Clara Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.472196, 37.726058 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Garfield St & Beverly St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.468333, 37.721170 ] } }
+{ "type": "Feature", "properties": { "name": "Gonzalez Dr. & Crespi Dr.", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.471273, 37.720950 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Miraloma Dr & Yerba Buena Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.459450, 37.732338 ] } }
+{ "type": "Feature", "properties": { "name": "Garfield St & Victoria St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.460630, 37.730708 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Monterey Blvd & Valdez Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.461252, 37.723699 ] } }
+{ "type": "Feature", "properties": { "name": "Monterey Blvd & Plymouth Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.460780, 37.725532 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Miramar Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.455029, 37.726941 ] } }
+{ "type": "Feature", "properties": { "name": "Grafton Ave & Faxon Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.455931, 37.724225 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Portola Dr & Woodside Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.446725, 37.748169 ] } }
+{ "type": "Feature", "properties": { "name": "Skyview Way & Glenview Dr", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.447584, 37.749001 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "100 O'Shaughnessy Blvd", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.449493, 37.740432 ] } }
+{ "type": "Feature", "properties": { "name": "Dawnview Way & Burnett Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.448270, 37.743503 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Teresita Blvd & Bella Vista Way", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.441554, 37.745981 ] } }
+{ "type": "Feature", "properties": { "name": "O'Shaughnessy Blvd & Del Vale Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.442756, 37.744776 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Diamond St & 24th St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.435181, 37.748899 ] } }
+{ "type": "Feature", "properties": { "name": "5157 Diamond Heights Blvd", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.435610, 37.748882 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Diamond St & Diamond Heights Blvd", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.435203, 37.739719 ] } }
+{ "type": "Feature", "properties": { "name": "Diamond Heights Blvd & Gold Mine Dr", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.436254, 37.740941 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Teresita Blvd & Foerster St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.449214, 37.731642 ] } }
+{ "type": "Feature", "properties": { "name": "Diamond St & Moffitt St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.444344, 37.734035 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "PHELAN AVE/CCSF (North Entrance)", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.451210, 37.722392 ] } }
+{ "type": "Feature", "properties": { "name": "Foerster St & Judson Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.449343, 37.728655 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "San Jose Ave & Ocean Ave", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.445073, 37.722969 ] } }
+{ "type": "Feature", "properties": { "name": "GENEVA AVE & GENEVA AVE", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.449729, 37.721662 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Baden St & Circular Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.437027, 37.730675 ] } }
+{ "type": "Feature", "properties": { "name": "Geneva Ave/Balboa Park BART", "clustered": true, "point_count": 25, "sqrt_point_count": 5, "point_count_abbreviated": "25" }, "geometry": { "type": "Point", "coordinates": [ -122.444558, 37.723580 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Otsego Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.436018, 37.723920 ] } }
+{ "type": "Feature", "properties": { "name": "Diamond St & Chenery St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.437305, 37.729334 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Persia Ave & Paris St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.433465, 37.722019 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & Onondaga Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.434838, 37.723665 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Mcallister St & Fillmore St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.430975, 37.774751 ] } }
 ,
@@ -523,17 +547,17 @@
 ,
 { "type": "Feature", "properties": { "name": "Graham St & Moraga Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.456231, 37.799035 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Presidio YMCA Center N-MB/SB", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.446833, 37.801002 ] } }
+{ "type": "Feature", "properties": { "name": "Presidio YMCA Center N-MB/SB", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.447133, 37.801002 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lombard St & Divisadero St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.443700, 37.797899 ] } }
+{ "type": "Feature", "properties": { "name": "Divisadero St & Francisco St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.443571, 37.798662 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Baker St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.444494, 37.795017 ] } }
+{ "type": "Feature", "properties": { "name": "Union St & Baker St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.445159, 37.793965 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Chestnut St & Pierce St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.435310, 37.800561 ] } }
+{ "type": "Feature", "properties": { "name": "Chestnut St & Scott St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.436018, 37.800917 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Pierce St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.437027, 37.793101 ] } }
+{ "type": "Feature", "properties": { "name": "Union St & Buchanan St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.436855, 37.793999 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & Pierce St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.434452, 37.789285 ] } }
+{ "type": "Feature", "properties": { "name": "Jackson St & Webster St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.434516, 37.790337 ] } }
 ,
 { "type": "Feature", "properties": { "name": "25th Ave & El Camino Del Mar" }, "geometry": { "type": "Point", "coordinates": [ -122.485135, 37.787539 ] } }
 ,
@@ -563,17 +587,19 @@
 ,
 { "type": "Feature", "properties": { "name": "Moscow St & France Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.428315, 37.714364 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geneva Ave & Brookdale Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.423658, 37.711139 ] } }
+{ "type": "Feature", "properties": { "name": "Geneva Ave & Brookdale Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.423272, 37.711801 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geneva Ave&Carter St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.421470, 37.710171 ] } }
+{ "type": "Feature", "properties": { "name": "Geneva Ave & Brookdale Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.423100, 37.709186 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Santos St & Velasco Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.415719, 37.711699 ] } }
+{ "type": "Feature", "properties": { "name": "1725 Sunnydale Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.415805, 37.712564 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geneva Ave & Rio Verde St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.413316, 37.707659 ] } }
+{ "type": "Feature", "properties": { "name": "Visitacion Ave & Schwerin St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.415633, 37.709203 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Wilde Ave & Delta St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.405269, 37.714381 ] } }
+{ "type": "Feature", "properties": { "name": "Geneva Street & Schwerin Street", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.412522, 37.707676 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bay Shore Blvd & Hester Ave", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.402544, 37.711648 ] } }
+{ "type": "Feature", "properties": { "name": "Wilde Ave & Delta St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.405891, 37.714228 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Wilde Ave & Brussels St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.402329, 37.712106 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Blanken Ave & Nueva Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.392159, 37.714364 ] } }
 ,
@@ -609,99 +635,103 @@
 ,
 { "type": "Feature", "properties": { "name": "1st St & Mission St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.394218, 37.789133 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sutter St & Buchanan St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.425654, 37.785606 ] } }
+{ "type": "Feature", "properties": { "name": "Sutter St & Buchanan St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.426083, 37.785606 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "O'Farrell St & Van Ness Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.426963, 37.778483 ] } }
+{ "type": "Feature", "properties": { "name": "Van Ness Ave & Geary Blvd", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.426641, 37.778907 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Haight St & Buchanan St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.422221, 37.778381 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Hyde St", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.415204, 37.783859 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & Hyde St", "clustered": true, "point_count": 23, "sqrt_point_count": 4.8, "point_count_abbreviated": "23" }, "geometry": { "type": "Point", "coordinates": [ -122.415311, 37.783910 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mcallister St & 7th St", "clustered": true, "point_count": 22, "sqrt_point_count": 4.69, "point_count_abbreviated": "22" }, "geometry": { "type": "Point", "coordinates": [ -122.416792, 37.776939 ] } }
+{ "type": "Feature", "properties": { "name": "Turk St & Jones St", "clustered": true, "point_count": 37, "sqrt_point_count": 6.08, "point_count_abbreviated": "37" }, "geometry": { "type": "Point", "coordinates": [ -122.418337, 37.775243 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 8th St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.422478, 37.771342 ] } }
+{ "type": "Feature", "properties": { "name": "Duboce Portal/Not a stop", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.426984, 37.766881 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Market St & 15th St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.425697, 37.766169 ] } }
+{ "type": "Feature", "properties": { "name": "Valencia St & 16th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.426791, 37.760418 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "18th St & Sanchez St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.426255, 37.759791 ] } }
+{ "type": "Feature", "properties": { "name": "18th St & Valencia St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.420182, 37.762725 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Valencia St & 20th St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.419152, 37.763557 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & 18th St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.413380, 37.765830 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "16th St & Shotwell St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.413337, 37.765389 ] } }
+{ "type": "Feature", "properties": { "name": "18th St & Mission St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.417650, 37.758654 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 20th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.415462, 37.758349 ] } }
+{ "type": "Feature", "properties": { "name": "Bryant St & 18th St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.408037, 37.781417 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Powell St", "clustered": true, "point_count": 29, "sqrt_point_count": 5.39, "point_count_abbreviated": "29" }, "geometry": { "type": "Point", "coordinates": [ -122.406063, 37.785012 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & 6th St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.402909, 37.784266 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "3rd St & Folsom St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.404540, 37.777855 ] } }
+{ "type": "Feature", "properties": { "name": "7th St & Howard St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.405698, 37.775226 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Brannan St & 8th ST", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.399948, 37.779025 ] } }
+{ "type": "Feature", "properties": { "name": "7th St & Brannan St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.397459, 37.781654 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "2nd St & Harrison St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.393296, 37.783130 ] } }
+{ "type": "Feature", "properties": { "name": "Brannan St & 3rd St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.392352, 37.781349 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "The Embarcadero & Townsend St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.394540, 37.777126 ] } }
+{ "type": "Feature", "properties": { "name": "Townsend St & 5th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.394562, 37.776295 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "3rd St & Terry A Francois Blvd", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.400978, 37.769239 ] } }
+{ "type": "Feature", "properties": { "name": "Third Street & Mission Rock St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.403059, 37.767780 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Vermont St & 17th St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.403445, 37.765219 ] } }
+{ "type": "Feature", "properties": { "name": "Rhode Island St & 15th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.403338, 37.764354 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Vermont St & 19th St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.404346, 37.757314 ] } }
+{ "type": "Feature", "properties": { "name": "Bryant St & 21st St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.404196, 37.756924 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Rhode Island St & 23rd St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.397501, 37.760656 ] } }
+{ "type": "Feature", "properties": { "name": "Carolina St & 22nd St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.397029, 37.761351 ] } }
 ,
 { "type": "Feature", "properties": { "name": "16th St & 4th St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.392352, 37.762980 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Wisconsin St & 23rd St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.392094, 37.757042 ] } }
+{ "type": "Feature", "properties": { "name": "Wisconsin St & 23rd St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.392373, 37.757144 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "24th St & Sanchez St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.427800, 37.749917 ] } }
+{ "type": "Feature", "properties": { "name": "Third Street & 23rd St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.423444, 37.750341 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noe St & 29th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.427306, 37.741297 ] } }
+{ "type": "Feature", "properties": { "name": "24th St & Guerrero St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.427220, 37.743792 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & Cortland Ave", "clustered": true, "point_count": 23, "sqrt_point_count": 4.8, "point_count_abbreviated": "23" }, "geometry": { "type": "Point", "coordinates": [ -122.420783, 37.745505 ] } }
+{ "type": "Feature", "properties": { "name": "Bemis St & Moffitt St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.424924, 37.739652 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 24th St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.413080, 37.749323 ] } }
+{ "type": "Feature", "properties": { "name": "Valencia St & 24th St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.417457, 37.749900 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cortland Ave & Elsie St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.413423, 37.739906 ] } }
+{ "type": "Feature", "properties": { "name": "Cesar Chavez St & Folsom St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.414324, 37.745539 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Cortland Ave & Andover St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.412372, 37.739957 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Bosworth St & Rotteck St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.428143, 37.731879 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Silver Ave & Congdon St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.427864, 37.722104 ] } }
+{ "type": "Feature", "properties": { "name": "Silver Ave & Congdon St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.427993, 37.722681 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Avalon Ave & La Grande Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.420783, 37.729198 ] } }
+{ "type": "Feature", "properties": { "name": "Prague St & Persia Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.423551, 37.725600 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Silver Ave & Cambridge St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.414539, 37.731981 ] } }
+{ "type": "Feature", "properties": { "name": "Crescent Ave & Andover St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.415097, 37.733356 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Felton St & Harvard St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.416835, 37.724497 ] } }
+{ "type": "Feature", "properties": { "name": "Silver Ave & Dartmouth St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.416964, 37.725872 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Woolsey St & Dartmouth St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.408745, 37.742926 ] } }
+{ "type": "Feature", "properties": { "name": "University St & Bacon St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.409496, 37.739855 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "228 Bay Shore Blvd", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.404411, 37.746608 ] } }
+{ "type": "Feature", "properties": { "name": "228 Bay Shore Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.404304, 37.747236 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cortland Ave & Hilton St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.403960, 37.740211 ] } }
+{ "type": "Feature", "properties": { "name": "Oakdale Ave & Bayshore Blvd", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.404454, 37.740568 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Wisconsin St & 25th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.396064, 37.750528 ] } }
+{ "type": "Feature", "properties": { "name": "Palou Ave & Industrial St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.396472, 37.749527 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Jerrold Ave & Selby St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.392609, 37.740805 ] } }
+{ "type": "Feature", "properties": { "name": "Jerrold Ave & Selby St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.393017, 37.740653 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Phelps St & Jerrold Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.396021, 37.736190 ] } }
+{ "type": "Feature", "properties": { "name": "3rd St & Evans Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.394991, 37.736953 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Girard ST & Burrows ST", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.404411, 37.728163 ] } }
+{ "type": "Feature", "properties": { "name": "San Bruno Ave & Felton St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.403316, 37.729453 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mansell St & Hamilton St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.402952, 37.722273 ] } }
+{ "type": "Feature", "properties": { "name": "Woolsey St & Bowdoin St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.405355, 37.723580 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Topeka Ave & Bridge View Dr", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.392180, 37.733135 ] } }
+{ "type": "Feature", "properties": { "name": "Mansell St & Brussels St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.399004, 37.726347 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "3rd St & Thornton Ave", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.394540, 37.724514 ] } }
+{ "type": "Feature", "properties": { "name": "Palou Ave & Newhall St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.391322, 37.732422 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Dyke Ave & Jennings St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.390141, 37.723682 ] } }
+{ "type": "Feature", "properties": { "name": "Armstrong Ave & 3rd St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.395012, 37.722885 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Gilman Ave & Ingalls St" }, "geometry": { "type": "Point", "coordinates": [ -122.391729, 37.720339 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Not a public stop", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.386837, 37.755380 ] } }
 ,
 { "type": "Feature", "properties": { "name": "3rd St & 25th St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.387288, 37.748577 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mendell St & Evans Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.383747, 37.739855 ] } }
+{ "type": "Feature", "properties": { "name": "Mendell St & Evans Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.384434, 37.740127 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Evans Ave & Middle Point Rd" }, "geometry": { "type": "Point", "coordinates": [ -122.379241, 37.737666 ] } }
+{ "type": "Feature", "properties": { "name": "Evans Ave & Keith St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.380378, 37.738396 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Cashmere St & La Salle Ave", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.383726, 37.732422 ] } }
 ,
@@ -725,7 +755,9 @@
 ] }
 ,
 { "type": "FeatureCollection", "properties": { "layer": "subway", "version": 2, "extent": 4096 }, "features": [
-{ "type": "Feature", "properties": { "name": "Metro Montgomery Station/Outbound", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.415054, 37.778517 ] } }
+{ "type": "Feature", "properties": { "name": "Metro Montgomery Station/Outbound", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.413294, 37.779823 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Metro Civic Center Station/Outbd", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.417371, 37.776770 ] } }
 ] }
 ] }
 ,
@@ -737,27 +769,27 @@
 ,
 { "type": "Feature", "properties": { "name": "Larkin St & Beach St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.421384, 37.806529 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hyde St & Beach St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.415848, 37.806597 ] } }
+{ "type": "Feature", "properties": { "name": "Hyde St & Beach St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.416213, 37.806665 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Chestnut St & Laguna St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.426941, 37.802291 ] } }
+{ "type": "Feature", "properties": { "name": "Powell St & Bay St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.426491, 37.802223 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Greenwich St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.426534, 37.795339 ] } }
+{ "type": "Feature", "properties": { "name": "North Point St & Larkin St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.425117, 37.798154 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Vallejo St", "clustered": true, "point_count": 23, "sqrt_point_count": 4.8, "point_count_abbreviated": "23" }, "geometry": { "type": "Point", "coordinates": [ -122.421255, 37.795186 ] } }
+{ "type": "Feature", "properties": { "name": "Sacramento St & Laguna St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.423251, 37.792762 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hyde St & Greenwich St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.414818, 37.801002 ] } }
+{ "type": "Feature", "properties": { "name": "Bush St &Van ness Ave", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.417049, 37.801239 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mason St & Vallejo St", "clustered": true, "point_count": 25, "sqrt_point_count": 5, "point_count_abbreviated": "25" }, "geometry": { "type": "Point", "coordinates": [ -122.416577, 37.793389 ] } }
+{ "type": "Feature", "properties": { "name": "Powell St & Lombard St", "clustered": true, "point_count": 23, "sqrt_point_count": 4.8, "point_count_abbreviated": "23" }, "geometry": { "type": "Point", "coordinates": [ -122.415462, 37.796238 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Pacific Ave & Mason St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.412007, 37.793185 ] } }
+{ "type": "Feature", "properties": { "name": "Hyde St & Sacramento St", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.413380, 37.792931 ] } }
 ,
 { "type": "Feature", "properties": { "name": "The Embarcadero & Grant St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.407179, 37.807258 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Lombard St & Grant Ave", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.406321, 37.801053 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "The Embarcadero & Green St", "clustered": true, "point_count": 26, "sqrt_point_count": 5.1, "point_count_abbreviated": "26" }, "geometry": { "type": "Point", "coordinates": [ -122.406363, 37.793881 ] } }
+{ "type": "Feature", "properties": { "name": "The Embarcadero & Green St", "clustered": true, "point_count": 25, "sqrt_point_count": 5, "point_count_abbreviated": "25" }, "geometry": { "type": "Point", "coordinates": [ -122.406385, 37.793932 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "POST & GRANT", "clustered": true, "point_count": 23, "sqrt_point_count": 4.8, "point_count_abbreviated": "23" }, "geometry": { "type": "Point", "coordinates": [ -122.400784, 37.792541 ] } }
+{ "type": "Feature", "properties": { "name": "California St & Grant Ave", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.400999, 37.792541 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Clay St & Drumm St", "clustered": true, "point_count": 38, "sqrt_point_count": 6.16, "point_count_abbreviated": "38" }, "geometry": { "type": "Point", "coordinates": [ -122.395184, 37.792694 ] } }
 ,
@@ -775,9 +807,13 @@
 ,
 { "type": "Feature", "properties": { "name": "Sutter St & Laguna St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.424817, 37.787217 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Polk St & Sutter St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.414432, 37.787624 ] } }
+{ "type": "Feature", "properties": { "name": "Polk St & Sutter St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.415333, 37.787708 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Powell St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.404346, 37.787607 ] } }
+{ "type": "Feature", "properties": { "name": "Mason St & Geary Blvd" }, "geometry": { "type": "Point", "coordinates": [ -122.409947, 37.787217 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Geary Blvd & Powell St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.405462, 37.787556 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Mission St & 2nd St" }, "geometry": { "type": "Point", "coordinates": [ -122.399840, 37.787861 ] } }
 ,
 { "type": "Feature", "properties": { "name": "2nd St & Howard St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.394841, 37.786962 ] } }
 ] }
@@ -829,9 +865,9 @@
 ,
 { "type": "Feature", "properties": { "name": "555 John Muir Dr", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.495949, 37.716316 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lake Merced Blvd & Higuera Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.484577, 37.716053 ] } }
+{ "type": "Feature", "properties": { "name": "Lake Merced Blvd & Higuera Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.484823, 37.715993 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Garces Dr & Bucareli Dr", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.484083, 37.712904 ] } }
+{ "type": "Feature", "properties": { "name": "Arballo Dr & Garces Dr", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.483901, 37.713761 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Font Blvd & Juan Bautisa Cir.", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.477968, 37.716477 ] } }
 ,
@@ -851,21 +887,21 @@
 ,
 { "type": "Feature", "properties": { "name": "Noriega St & 23rd Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.478697, 37.753946 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 48th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.505670, 37.752411 ] } }
+{ "type": "Feature", "properties": { "name": "Noriega St & 48th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.505723, 37.752547 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "46th Ave & Pacheco St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.506313, 37.747321 ] } }
+{ "type": "Feature", "properties": { "name": "46th Ave & Ortega St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.506013, 37.748458 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "46th Ave & Quintara St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.504125, 37.748110 ] } }
+{ "type": "Feature", "properties": { "name": "Rivera St & 48th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.504843, 37.747126 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 41st Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.500402, 37.750935 ] } }
+{ "type": "Feature", "properties": { "name": "Noriega St & 42nd Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.499501, 37.753225 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Quintara St & 41st Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.498986, 37.747618 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & 44th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.500391, 37.747567 ] } }
 ,
 { "type": "Feature", "properties": { "name": "46th Ave & Santiago St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.504597, 37.742409 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "46th Ave & Ulloa St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.504382, 37.738235 ] } }
+{ "type": "Feature", "properties": { "name": "46th Ave & Ulloa St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.504607, 37.737785 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Taraval St & 44th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.499876, 37.741993 ] } }
+{ "type": "Feature", "properties": { "name": "Taraval St & 44th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.500327, 37.741959 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Great Hwy & Sloat Blvd", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.505176, 37.735511 ] } }
 ,
@@ -877,7 +913,9 @@
 ,
 { "type": "Feature", "properties": { "name": "John Muir Dr & Skyline Blvd", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.496239, 37.744241 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "39th Ave & Quintara St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.495230, 37.746956 ] } }
+{ "type": "Feature", "properties": { "name": "39th Ave & Quintara St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.495348, 37.747177 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Sunset Blvd & Rivera St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.494705, 37.745955 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Quintara St & 33rd Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.488664, 37.748068 ] } }
 ,
@@ -885,9 +923,11 @@
 ,
 { "type": "Feature", "properties": { "name": "Sunset Blvd & Taraval St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.494040, 37.742239 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sunset Blvd & Ulloa St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.493503, 37.739024 ] } }
+{ "type": "Feature", "properties": { "name": "Sunset Blvd & Ulloa St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.494168, 37.738447 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Taraval St & 32nd Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.487720, 37.742528 ] } }
+{ "type": "Feature", "properties": { "name": "Taraval St & 32nd Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.488042, 37.742969 ] } }
+,
+{ "type": "Feature", "properties": { "name": "30th Ave & Ulloa St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.487302, 37.740746 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Vicente St & 30th Ave" }, "geometry": { "type": "Point", "coordinates": [ -122.487130, 37.738769 ] } }
 ,
@@ -903,11 +943,11 @@
 ,
 { "type": "Feature", "properties": { "name": "19th Ave & Ulloa St" }, "geometry": { "type": "Point", "coordinates": [ -122.475682, 37.741289 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sloat Blvd & 39th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.495070, 37.733831 ] } }
+{ "type": "Feature", "properties": { "name": "Sloat Blvd & 39th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.495166, 37.733907 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sunset Blvd & Ocean Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.493664, 37.731396 ] } }
+{ "type": "Feature", "properties": { "name": "Sunset Blvd & Sloat Blvd", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.493804, 37.732270 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sunset Blvd & Lake Merced Blvd", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.491636, 37.732940 ] } }
+{ "type": "Feature", "properties": { "name": "Sunset Blvd & Lake Merced Blvd", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.492012, 37.732422 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Sloat Blvd & Constanso Way" }, "geometry": { "type": "Point", "coordinates": [ -122.489254, 37.734238 ] } }
 ,
@@ -925,7 +965,9 @@
 ,
 { "type": "Feature", "properties": { "name": "170 Buckingham Way", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.476916, 37.726364 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Font Blvd & Tapia Dr", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.478633, 37.719626 ] } }
+{ "type": "Feature", "properties": { "name": "Font Blvd & Tapia Dr", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.479126, 37.719719 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Gonzalez Dr & Cardenas Ave" }, "geometry": { "type": "Point", "coordinates": [ -122.475629, 37.719100 ] } }
 ,
 { "type": "Feature", "properties": { "name": "19th Ave & Taraval St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.475468, 37.742638 ] } }
 ,
@@ -959,11 +1001,13 @@
 ,
 { "type": "Feature", "properties": { "name": "Point Lobos Ave & 47th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.505337, 37.780518 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "LEGION OF HONOR", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.501453, 37.781646 ] } }
+{ "type": "Feature", "properties": { "name": "LEGION OF HONOR", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.501603, 37.782078 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & 45th Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.506002, 37.776498 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 39th Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.503470, 37.779254 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 43rd Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.506013, 37.773462 ] } }
+{ "type": "Feature", "properties": { "name": "45th Ave & Balboa St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.505831, 37.774667 ] } }
+,
+{ "type": "Feature", "properties": { "name": "45th Ave & Cabrillo St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.506217, 37.772547 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Fulton St & 43rd Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.502140, 37.774539 ] } }
 ,
@@ -977,7 +1021,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Lincoln Way & 47th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.506378, 37.763370 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & 48th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.506657, 37.760079 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 48th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.506742, 37.760232 ] } }
+,
+{ "type": "Feature", "properties": { "name": "46th Ave & Kirkham St" }, "geometry": { "type": "Point", "coordinates": [ -122.505713, 37.758484 ] } }
 ,
 { "type": "Feature", "properties": { "name": "46th Ave & Lawton St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.504146, 37.758162 ] } }
 ,
@@ -985,31 +1031,33 @@
 ,
 { "type": "Feature", "properties": { "name": "Geary Blvd & 36th Ave", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.493439, 37.780806 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 28th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.489973, 37.781824 ] } }
+{ "type": "Feature", "properties": { "name": "California St & 28th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.490134, 37.781824 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 27th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.490757, 37.779195 ] } }
+{ "type": "Feature", "properties": { "name": "Clement St & 29th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.488031, 37.781230 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "33rd Ave & Anza St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.494104, 37.775532 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 37th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.494104, 37.776634 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & 33rd Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.491722, 37.775345 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & 37th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.494951, 37.772063 ] } }
+,
+{ "type": "Feature", "properties": { "name": "32ND AVE & ANZA St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.491282, 37.776405 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Balboa St & 28th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.489008, 37.773853 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & 30th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.485993, 37.780967 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & 30th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.486358, 37.779984 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 22nd Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.484137, 37.781697 ] } }
+{ "type": "Feature", "properties": { "name": "25th Ave & California St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.483933, 37.783647 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 22nd Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.481852, 37.781188 ] } }
+{ "type": "Feature", "properties": { "name": "25th Ave & Clement St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.483879, 37.781179 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 19th Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.479041, 37.783223 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 22nd Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.479523, 37.782901 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & 20th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.477549, 37.781061 ] } }
+{ "type": "Feature", "properties": { "name": "Clement St & 20th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.478654, 37.781654 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "25th Ave & Anza St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.483954, 37.776795 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 17th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.482409, 37.777813 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "25th Ave & Cabrillo St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.484223, 37.773174 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 23rd Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.483740, 37.774192 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & 22nd Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.480553, 37.775252 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & 25th Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.481369, 37.774565 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Balboa St & 19th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.478000, 37.774980 ] } }
 ,
@@ -1023,25 +1071,29 @@
 ,
 { "type": "Feature", "properties": { "name": "Sunset Blvd & Lawton St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.495542, 37.755049 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 34th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.489630, 37.759256 ] } }
+{ "type": "Feature", "properties": { "name": "Noriega St & 34th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.490585, 37.758603 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 33rd Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.489576, 37.753649 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 28th Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.488375, 37.758629 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Noriega St & 32nd Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.489061, 37.753700 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Lincoln Way & 27th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.483439, 37.765143 ] } }
 ,
 { "type": "Feature", "properties": { "name": "23rd Ave & Irving St" }, "geometry": { "type": "Point", "coordinates": [ -122.481487, 37.763133 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "22nd Ave & Lincoln Way", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.477968, 37.765032 ] } }
+{ "type": "Feature", "properties": { "name": "22nd Ave & Lincoln Way", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.478086, 37.765244 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & 28th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.483397, 37.761445 ] } }
+{ "type": "Feature", "properties": { "name": "19th Ave & Irving St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.481852, 37.762445 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "23rd Ave & Kirkham St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.483472, 37.755855 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 25th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.482055, 37.760817 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 24th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.479448, 37.759655 ] } }
+{ "type": "Feature", "properties": { "name": "Noriega St & 28th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.484158, 37.753912 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & 19th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.478182, 37.758272 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 22nd Ave", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.478032, 37.760961 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "22nd Ave & Noriega St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.477109, 37.754913 ] } }
+{ "type": "Feature", "properties": { "name": "19th Ave & Lawton St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.479341, 37.755728 ] } }
+,
+{ "type": "Feature", "properties": { "name": "19th Ave & Moraga St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.476487, 37.755066 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Noriega St & 48th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.505541, 37.752920 ] } }
 ,
@@ -1051,7 +1103,9 @@
 ,
 { "type": "Feature", "properties": { "name": "19th Ave & Ortega St" }, "geometry": { "type": "Point", "coordinates": [ -122.476187, 37.752716 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 16th Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.475361, 37.783672 ] } }
+{ "type": "Feature", "properties": { "name": "California St & 16th Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.475361, 37.784317 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Clement St & 16th Ave" }, "geometry": { "type": "Point", "coordinates": [ -122.475361, 37.782392 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Fulton St & 16th Ave" }, "geometry": { "type": "Point", "coordinates": [ -122.474921, 37.773047 ] } }
 ,
@@ -1107,15 +1161,17 @@
 ,
 { "type": "Feature", "properties": { "name": "FONT BLVD & GONZALEZ DR", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.475897, 37.716732 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cambon Dr & Castelo Ave", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.473311, 37.716409 ] } }
+{ "type": "Feature", "properties": { "name": "Cambon Dr & Castelo Ave", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.473429, 37.716426 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Junipero Serra Blvd & Font Blvd", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.473022, 37.713863 ] } }
+{ "type": "Feature", "properties": { "name": "19th Ave & Randolph St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.473075, 37.714279 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Junipero Serra Blvd & Brotherhood Way", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.470415, 37.713226 ] } }
+{ "type": "Feature", "properties": { "name": "JUNIPERO SERRA RAMP & BROTHERHOOD WAY", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.471809, 37.712564 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Randolph St & Arch St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.468269, 37.712361 ] } }
+{ "type": "Feature", "properties": { "name": "19th Ave & Randolph St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.469256, 37.714355 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Brotherhood Way & Arch ST", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.466456, 37.711724 ] } }
+{ "type": "Feature", "properties": { "name": "Brotherhood Way & St Charles Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.467786, 37.711843 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Alemany Blvd & Victoria St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.464997, 37.711733 ] } }
 ,
 { "type": "Feature", "properties": { "name": "St Charles Ave & Belle Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.469084, 37.707183 ] } }
 ,
@@ -1137,11 +1193,11 @@
 ,
 { "type": "Feature", "properties": { "name": "Mission St & Whittier St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.448388, 37.710349 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Niagra Ave & Alemany Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.444515, 37.713371 ] } }
+{ "type": "Feature", "properties": { "name": "Niagra Ave & Alemany Blvd", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.444161, 37.713855 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & Guttenberg St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.449150, 37.710485 ] } }
+{ "type": "Feature", "properties": { "name": "Morse St & Lowell St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.447240, 37.711249 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & Oliver St" }, "geometry": { "type": "Point", "coordinates": [ -122.450062, 37.709619 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & Acton St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.451038, 37.709339 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Alemany Blvd & Geneva Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.441093, 37.716740 ] } }
 ,
@@ -1191,17 +1247,19 @@
 ,
 { "type": "Feature", "properties": { "name": "Santiago St & 14th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.467636, 37.749951 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "10th Ave & Pacheco St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.467539, 37.749467 ] } }
+{ "type": "Feature", "properties": { "name": "10th Ave & Pacheco St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.467604, 37.749535 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "19th Ave & Taraval St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.473022, 37.742816 ] } }
+{ "type": "Feature", "properties": { "name": "Quintara St & Cragmont Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.472678, 37.745132 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Taraval St & 17th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.472410, 37.742714 ] } }
 ,
 { "type": "Feature", "properties": { "name": "15th Ave & Ulloa St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.473440, 37.739668 ] } }
 ,
 { "type": "Feature", "properties": { "name": "West Portal Ave & 15th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.469642, 37.739490 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ulloa St & Lenox Way", "clustered": true, "point_count": 27, "sqrt_point_count": 5.2, "point_count_abbreviated": "27" }, "geometry": { "type": "Point", "coordinates": [ -122.466574, 37.740220 ] } }
+{ "type": "Feature", "properties": { "name": "Ulloa St & Lenox Way", "clustered": true, "point_count": 26, "sqrt_point_count": 5.1, "point_count_abbreviated": "26" }, "geometry": { "type": "Point", "coordinates": [ -122.466574, 37.740254 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Portola Ave & Claremont Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.465147, 37.739694 ] } }
+{ "type": "Feature", "properties": { "name": "Vicente St & West Portal Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.465630, 37.739618 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Laguna Honda Blvd & Clarendon Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.461199, 37.751037 ] } }
 ,
@@ -1217,17 +1275,19 @@
 ,
 { "type": "Feature", "properties": { "name": "Portola Dr & Waithman Way", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.455931, 37.742451 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "MYRA WAY &  DALEWOOD", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.471455, 37.734366 ] } }
+{ "type": "Feature", "properties": { "name": "MYRA WAY &  DALEWOOD", "clustered": true, "point_count": 23, "sqrt_point_count": 4.8, "point_count_abbreviated": "23" }, "geometry": { "type": "Point", "coordinates": [ -122.471455, 37.734349 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Junipero Serra Blvd & Ocean Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.473118, 37.731175 ] } }
+{ "type": "Feature", "properties": { "name": "West Portal/Sloat/St Francis Circle", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.473859, 37.731625 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Saint Francis Blvd & San Fernando Way", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.467968, 37.734832 ] } }
+{ "type": "Feature", "properties": { "name": "Eucalyptus Dr & Junipero Serra Blvd", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.470640, 37.732643 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Santa Clara Ave & Monterey Blvd", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.467829, 37.730157 ] } }
+{ "type": "Feature", "properties": { "name": "Saint Francis Blvd & Santa Clara Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.467411, 37.732278 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "19th Ave & Winston Dr", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.474921, 37.726890 ] } }
+{ "type": "Feature", "properties": { "name": "Ocean Ave & Aptos Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.472239, 37.727442 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "19TH AVE & HOLLOWAY AVE", "clustered": true, "point_count": 22, "sqrt_point_count": 4.69, "point_count_abbreviated": "22" }, "geometry": { "type": "Point", "coordinates": [ -122.474309, 37.720661 ] } }
+{ "type": "Feature", "properties": { "name": "19TH AVE & HOLLOWAY AVE", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.474706, 37.720822 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Beverly St & Garfield St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.471842, 37.719668 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Ocean Ave & Cerritos Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.466670, 37.727221 ] } }
 ,
@@ -1241,41 +1301,45 @@
 ,
 { "type": "Feature", "properties": { "name": "Monterey Blvd & Faxon Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.457175, 37.731082 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Victoria St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.462776, 37.725473 ] } }
+{ "type": "Feature", "properties": { "name": "Ocean Ave & Victoria St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.464256, 37.726007 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Garfield St & Bright St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.461585, 37.719982 ] } }
+{ "type": "Feature", "properties": { "name": "Ocean Ave & Jules Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.462186, 37.722443 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Miramar Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.455963, 37.723784 ] } }
+{ "type": "Feature", "properties": { "name": "Grafton Ave & Jules Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.459514, 37.721849 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "GRAFTON AVE & Capitol AVE", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.456435, 37.720339 ] } }
+{ "type": "Feature", "properties": { "name": "Plymouth Ave & Ocean Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.456027, 37.722138 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Olympia Way & Dellbrook Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.451564, 37.750604 ] } }
+{ "type": "Feature", "properties": { "name": "Plymouth Ave & Holloway Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.455115, 37.726644 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Panorama Dr & Starview Way", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.450813, 37.750137 ] } }
 ,
 { "type": "Feature", "properties": { "name": "City View Way & Knollview Way", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.451532, 37.746210 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "PARKRIDGE DR & CRESTLINE DR", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.444955, 37.751079 ] } }
+{ "type": "Feature", "properties": { "name": "PARKRIDGE DR & CRESTLINE DR", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.445062, 37.751105 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Grand View Ave & 24th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.445202, 37.748076 ] } }
+{ "type": "Feature", "properties": { "name": "Corbett Ave & Cuesta Ct", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.445363, 37.748543 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Grand View Ave & Clipper St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.446350, 37.745624 ] } }
+{ "type": "Feature", "properties": { "name": "DIAMOND HEIGHTS BLVD & PORTOLA", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.445771, 37.746201 ] } }
 ,
 { "type": "Feature", "properties": { "name": "100 O'Shaughnessy Blvd", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.450019, 37.741874 ] } }
 ,
 { "type": "Feature", "properties": { "name": "555 Myra Way", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.450813, 37.738981 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "O'Shaughnessy Blvd & Del Vale Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.446800, 37.740237 ] } }
+{ "type": "Feature", "properties": { "name": "O'Shaughnessy Blvd & Del Vale Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.446940, 37.740551 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Teresita Blvd & El Sereno Ct", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.445728, 37.737369 ] } }
+{ "type": "Feature", "properties": { "name": "Teresita Blvd & El Sereno Ct", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.446135, 37.737785 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "O'Shaughnessy Blvd & Malta Dr", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.441071, 37.749985 ] } }
+{ "type": "Feature", "properties": { "name": "O'Shaughnessy Blvd & Malta Dr", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.441962, 37.748246 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Douglass St & 24th St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.440224, 37.748025 ] } }
+{ "type": "Feature", "properties": { "name": "Eureka St & 23rd St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.439097, 37.750536 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Diamond Heights Blvd & Duncan St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.436233, 37.750740 ] } }
+{ "type": "Feature", "properties": { "name": "Duncan St & Amber Dr", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.439526, 37.747100 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Castro St & Elizabeth St", "clustered": true, "point_count": 20, "sqrt_point_count": 4.47, "point_count_abbreviated": "20" }, "geometry": { "type": "Point", "coordinates": [ -122.434376, 37.749620 ] } }
+{ "type": "Feature", "properties": { "name": "Diamond St & 24th St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.434484, 37.751334 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Diamond St & Duncan St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.434280, 37.746931 ] } }
+{ "type": "Feature", "properties": { "name": "Castro St & 25th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.435310, 37.747491 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Castro St & 26th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.433196, 37.748178 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Diamond Heights Blvd & Gold Mine Dr", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.437681, 37.743605 ] } }
 ,
@@ -1285,29 +1349,29 @@
 ,
 { "type": "Feature", "properties": { "name": "Diamond St & Surrey St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.433261, 37.736453 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Teresita Blvd & Foerster St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.450856, 37.731285 ] } }
+{ "type": "Feature", "properties": { "name": "Teresita Blvd & Foerster St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.450824, 37.731489 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judson Ave & Gennessee St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.448292, 37.731812 ] } }
+{ "type": "Feature", "properties": { "name": "Judson Ave & Gennessee St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.449504, 37.729928 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "900 Teresita Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.445642, 37.733381 ] } }
+{ "type": "Feature", "properties": { "name": "Teresita Blvd & Foerster St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.446082, 37.734230 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Monterey Blvd & Edna St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.445331, 37.731489 ] } }
+{ "type": "Feature", "properties": { "name": "Monterey Blvd & Detroit St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.445652, 37.731557 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "PHELAN AVE/CCSF (North Entrance)", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.452186, 37.723750 ] } }
+{ "type": "Feature", "properties": { "name": "Monterey Blvd & Detroit St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.449558, 37.727696 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Howth St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.450953, 37.720958 ] } }
+{ "type": "Feature", "properties": { "name": "PHELAN AVE/CCSF (South Entrance)", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.451940, 37.723309 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Howth St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.449590, 37.721629 ] } }
+{ "type": "Feature", "properties": { "name": "Grafton Ave & Harold Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.450684, 37.720950 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave&I-280 on-ramp NE-NS/SB", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.445856, 37.722554 ] } }
+{ "type": "Feature", "properties": { "name": "Ocean Ave&I-280 on-ramp NE-NS/SB", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.445416, 37.723063 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geneva Ave/Balboa Park BART", "clustered": true, "point_count": 40, "sqrt_point_count": 6.32, "point_count_abbreviated": "40" }, "geometry": { "type": "Point", "coordinates": [ -122.446414, 37.720890 ] } }
+{ "type": "Feature", "properties": { "name": "Geneva Ave/Balboa Park BART", "clustered": true, "point_count": 42, "sqrt_point_count": 6.48, "point_count_abbreviated": "42" }, "geometry": { "type": "Point", "coordinates": [ -122.446457, 37.720899 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Geneva Ave at Cayuga Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.442166, 37.726355 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Monterey Blvd & Baden St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.439966, 37.730055 ] } }
+{ "type": "Feature", "properties": { "name": "Monterey Blvd & Baden St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.440052, 37.729996 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Monterey Blvd & Acadia St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.436522, 37.732660 ] } }
+{ "type": "Feature", "properties": { "name": "Circular Ave & Baden St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.437541, 37.731888 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Diamond St & Chenery St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.433894, 37.733466 ] } }
 ,
@@ -1317,9 +1381,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Cayuga Ave & Onondaga Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.438893, 37.720279 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ocean Ave & Persia Ave", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.434967, 37.724208 ] } }
+{ "type": "Feature", "properties": { "name": "Ocean Ave & Persia Ave", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.434849, 37.724361 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Persia Ave & Paris St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.433615, 37.722010 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & Russia Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.434312, 37.721900 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Naples St & Russia Ave" }, "geometry": { "type": "Point", "coordinates": [ -122.432413, 37.719201 ] } }
 ,
@@ -1365,53 +1429,59 @@
 ,
 { "type": "Feature", "properties": { "name": "19th Ave & Ortega St" }, "geometry": { "type": "Point", "coordinates": [ -122.476187, 37.752716 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 16th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.473054, 37.784266 ] } }
+{ "type": "Feature", "properties": { "name": "California St & 16th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.472829, 37.784452 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 15th Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.472185, 37.781468 ] } }
+{ "type": "Feature", "properties": { "name": "Clement St & 16th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.472947, 37.782545 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & 10th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.466960, 37.784537 ] } }
+{ "type": "Feature", "properties": { "name": "14th  Avenue & Geary Boulevard", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.471337, 37.781544 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 10th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.466606, 37.782468 ] } }
+{ "type": "Feature", "properties": { "name": "California St & 8th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.466745, 37.783986 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Clement St & 8th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.466209, 37.782646 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Balboa St & 14th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.472335, 37.776066 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Fulton St & Park Presidio Blvd", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.471648, 37.773200 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 10th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.466810, 37.775922 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & 10th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.466370, 37.776312 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & 10th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.466520, 37.773649 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & 12th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.466938, 37.773590 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cornwall St & 5th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.462915, 37.784520 ] } }
+{ "type": "Feature", "properties": { "name": "Cornwall St & 5th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.462282, 37.785156 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clement St & 4th Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.462615, 37.781688 ] } }
+{ "type": "Feature", "properties": { "name": "6th Ave & Clement St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.463462, 37.782197 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sacramento St & Cherry St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.456757, 37.785182 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & 3rd Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.458924, 37.784342 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Euclid Ave & Spruce St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.458216, 37.782316 ] } }
+{ "type": "Feature", "properties": { "name": "Euclid Ave & Jordan Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.456886, 37.784096 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Commonwealth St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.462969, 37.777660 ] } }
+{ "type": "Feature", "properties": { "name": "Arguello Blvd & Geary Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.457873, 37.781307 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Balboa St & 4th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.463301, 37.774285 ] } }
+{ "type": "Feature", "properties": { "name": "6th Ave & Anza St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.463580, 37.777245 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & 4th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.459096, 37.776600 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & 6th Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.463226, 37.773776 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Turk St & Stanyan St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.457047, 37.775650 ] } }
+{ "type": "Feature", "properties": { "name": "Balboa St & Arguello Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.457433, 37.777397 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & Stanyan StW", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.454300, 37.773310 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & Arguello Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.456478, 37.774539 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Hayes St & Stanyan St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.454064, 37.772462 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Lincoln Way & 17th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.473140, 37.765635 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Judah St & Funston Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.468473, 37.767679 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lincoln Way & 11th Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.466938, 37.765210 ] } }
+{ "type": "Feature", "properties": { "name": "Lincoln Way & 11th Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.466992, 37.765355 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Irving St & 9th Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.469417, 37.761852 ] } }
+{ "type": "Feature", "properties": { "name": "9th Ave & Irving St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.468762, 37.761979 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Judah St & Funston Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.472721, 37.758315 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 15th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.472432, 37.760147 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noriega St & 16th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.471509, 37.757509 ] } }
+{ "type": "Feature", "properties": { "name": "16th Ave & Moraga St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.473161, 37.755253 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lawton St & Funston Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.467014, 37.758883 ] } }
+{ "type": "Feature", "properties": { "name": "Judah St & 12th Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.468441, 37.759740 ] } }
+,
+{ "type": "Feature", "properties": { "name": "9th Ave & Kirkham St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.465951, 37.758764 ] } }
 ,
 { "type": "Feature", "properties": { "name": "9th Ave & Moraga St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.465726, 37.755660 ] } }
 ,
@@ -1421,87 +1491,97 @@
 ,
 { "type": "Feature", "properties": { "name": "Lincoln Way & Arguello Blvd", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.456746, 37.764702 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lawton St & 7th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.463409, 37.758111 ] } }
+{ "type": "Feature", "properties": { "name": "Lawton St & 7th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.463366, 37.758383 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "1697 7th Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.462497, 37.755490 ] } }
+{ "type": "Feature", "properties": { "name": "1697 7th Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.463226, 37.755965 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Warren Dr & Christopher Dr" }, "geometry": { "type": "Point", "coordinates": [ -122.459975, 37.753760 ] } }
+{ "type": "Feature", "properties": { "name": "345 Warren Dr E", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.460791, 37.754549 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "117 Warren Dr", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.455341, 37.765143 ] } }
+{ "type": "Feature", "properties": { "name": "117 Warren Dr", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.456317, 37.754506 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Euclid Ave & Spruce St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.450480, 37.785266 ] } }
+{ "type": "Feature", "properties": { "name": "California St & Spruce St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.451586, 37.785784 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Spruce St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.451564, 37.781926 ] } }
+{ "type": "Feature", "properties": { "name": "Euclid Ave & Collins St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.450953, 37.783486 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sacramento St & Walnut St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.446275, 37.786360 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & Collins St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.447637, 37.786004 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sutter St & Baker St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.445889, 37.782918 ] } }
+{ "type": "Feature", "properties": { "name": "Euclid Ave & Presidio Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.445041, 37.785436 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Baker St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.450556, 37.778949 ] } }
+{ "type": "Feature", "properties": { "name": "Masonic Ave & Geary Blvd", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.446200, 37.782451 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Turk St & Roselyn Ter", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.451586, 37.774904 ] } }
+{ "type": "Feature", "properties": { "name": "Turk St & Parker Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.451510, 37.778059 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Fulton St & Clayton St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.451982, 37.774226 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Hayes St & Cole St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.447712, 37.776905 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fulton St & Masonic Ave", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.445266, 37.776592 ] } }
+{ "type": "Feature", "properties": { "name": "Fulton St & Masonic Ave", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.444955, 37.776999 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Masonic Ave & Hayes St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.445019, 37.773666 ] } }
+{ "type": "Feature", "properties": { "name": "Hayes St & Ashbury St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.445416, 37.773683 ] } }
 ,
 { "type": "Feature", "properties": { "name": "California St & Divisadero St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.440052, 37.786284 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sutter St & Scott St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.439376, 37.783062 ] } }
+{ "type": "Feature", "properties": { "name": "Sutter St & Scott St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.439430, 37.783359 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geary Blvd & Scott St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.437649, 37.781807 ] } }
+{ "type": "Feature", "properties": { "name": "Divisadero St & Ellis St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.437981, 37.781790 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Sutter St & Steiner St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.433357, 37.785724 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Eddy St & Pierce St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.435557, 37.780543 ] } }
+{ "type": "Feature", "properties": { "name": "Eddy St & Pierce St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.434527, 37.781069 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Turk St & Broderick St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.438893, 37.777703 ] } }
+{ "type": "Feature", "properties": { "name": "Mcallister St & Baker St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.439601, 37.777821 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Divisadero St & Hayes St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.439419, 37.774022 ] } }
+{ "type": "Feature", "properties": { "name": "Divisadero St & Fulton St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.439666, 37.774319 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Divisadero St & Oak St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.436436, 37.774904 ] } }
+{ "type": "Feature", "properties": { "name": "Hayes St & Divisadero St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.436973, 37.774853 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hayes St & Pierce St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.432832, 37.776812 ] } }
+{ "type": "Feature", "properties": { "name": "Hayes St & Scott St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.433615, 37.776448 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Divisadero St & Haight St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.435664, 37.771402 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Haight St & Stanyan St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.451510, 37.768807 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cole St & Frederick St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.451360, 37.765423 ] } }
+{ "type": "Feature", "properties": { "name": "Cole St & Frederick St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.452133, 37.765210 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Parnassus Ave & Cole St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.447927, 37.767017 ] } }
+{ "type": "Feature", "properties": { "name": "Carl St & Cole St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.448539, 37.766661 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Frederick St & Ashbury St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.445942, 37.767738 ] } }
+{ "type": "Feature", "properties": { "name": "Frederick St & Clayton St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.445964, 37.768128 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ashbury St & Clifford Ter", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.444440, 37.764159 ] } }
+{ "type": "Feature", "properties": { "name": "Clayton St & Parnassus Ave", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.445931, 37.764693 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cole St & 17th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.449965, 37.759443 ] } }
+{ "type": "Feature", "properties": { "name": "414 Roosevelt Way", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.443314, 37.763853 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Marview Way & Panorama Dr", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.446307, 37.760164 ] } }
+{ "type": "Feature", "properties": { "name": "Cole St & 17th St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.449086, 37.761436 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "320 Corbett Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.444150, 37.759808 ] } }
+{ "type": "Feature", "properties": { "name": "Panorama Dr & Dellbrook Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.450287, 37.756279 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Carmel St & Belvedere St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.445159, 37.760571 ] } }
+,
+{ "type": "Feature", "properties": { "name": "18th St & Market St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.444408, 37.758518 ] } }
 ,
 { "type": "Feature", "properties": { "name": "539 Corbett Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.443217, 37.755609 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Buena Vista Ave E & Buena Vista Ter", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.438722, 37.767271 ] } }
+{ "type": "Feature", "properties": { "name": "Buena Vista Ave E & Buena Vista Ter", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.438496, 37.767458 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Roosevelt Way & Museum Way" }, "geometry": { "type": "Point", "coordinates": [ -122.441018, 37.765363 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Corbett Ave & Douglass St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.436458, 37.766542 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Duboce St/Noe St/Duboce Park", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.434151, 37.767500 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Market St & Castro St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.436125, 37.762624 ] } }
+{ "type": "Feature", "properties": { "name": "Market St & Castro St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.435514, 37.762810 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "18th St & Hattie St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.438453, 37.760537 ] } }
+{ "type": "Feature", "properties": { "name": "Corbett Ave & Ord St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.439140, 37.760953 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Grand View Ave & 21st St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.438807, 37.755210 ] } }
+{ "type": "Feature", "properties": { "name": "Eureka St & 19th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.440127, 37.755533 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "18th St & Castro St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.434452, 37.760198 ] } }
+{ "type": "Feature", "properties": { "name": "20th St & Eureka St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.437037, 37.757297 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "20th St & Collingwood St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.434838, 37.756406 ] } }
+{ "type": "Feature", "properties": { "name": "Castro St & 19th St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.434344, 37.759350 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Castro St & 22nd St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.453184, 37.753548 ] } }
+{ "type": "Feature", "properties": { "name": "Castro St & 20th St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.434505, 37.755753 ] } }
+,
+{ "type": "Feature", "properties": { "name": "15th Ave & Ortega St" }, "geometry": { "type": "Point", "coordinates": [ -122.472056, 37.752682 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Ortega St & 10th Ave", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.466059, 37.752835 ] } }
 ,
@@ -1519,9 +1599,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Fillmore St & Oak St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.430847, 37.774014 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "14th St & Sanchez St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.431201, 37.766797 ] } }
+{ "type": "Feature", "properties": { "name": "14th St & Sanchez St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.431190, 37.767602 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Market St & Sanchez St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.431169, 37.765660 ] } }
+{ "type": "Feature", "properties": { "name": "Sanchez St & 15th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.431190, 37.765821 ] } }
 ] }
 ,
 { "type": "FeatureCollection", "properties": { "layer": "subway", "version": 2, "extent": 4096 }, "features": [
@@ -1553,9 +1633,9 @@
 ,
 { "type": "Feature", "properties": { "name": "LETTERMAN HOSPITAL", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.450094, 37.798111 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Broderick St & Jefferson St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.444848, 37.802248 ] } }
+{ "type": "Feature", "properties": { "name": "Broderick St & Jefferson St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.444537, 37.802748 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lyon St & Greenwich St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.444140, 37.799290 ] } }
+{ "type": "Feature", "properties": { "name": "Lombard St & Lyon St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.444644, 37.799154 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Presidio Blvd & Sumner Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.451607, 37.796594 ] } }
 ,
@@ -1571,11 +1651,13 @@
 ,
 { "type": "Feature", "properties": { "name": "Chestnut St & Buchanan St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.435460, 37.799696 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Buchanan St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.436984, 37.796873 ] } }
+{ "type": "Feature", "properties": { "name": "Union St & Buchanan St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.436962, 37.796907 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Jackson St & Divisadero St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.440556, 37.790532 ] } }
+{ "type": "Feature", "properties": { "name": "Steiner St & Union St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.440106, 37.792863 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & Pierce St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.436115, 37.793965 ] } }
+{ "type": "Feature", "properties": { "name": "Divisadero St & Clay St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.438990, 37.791625 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Steiner St & Vallejo St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.435642, 37.793906 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Jackson St & Webster St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.434988, 37.791117 ] } }
 ,
@@ -1589,7 +1671,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Fillmore St & Pine St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.433604, 37.787878 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Chestnut St & Laguna St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.431297, 37.801112 ] } }
+{ "type": "Feature", "properties": { "name": "Chestnut St & Laguna St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.431383, 37.801426 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Lombard St & Laguna St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.431104, 37.800468 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Jackson St & Buchanan St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.431190, 37.792439 ] } }
 ,
@@ -1623,9 +1707,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Moscow St & France Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.429527, 37.717606 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "South Hill Blvd & Chicago Way", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.428304, 37.712191 ] } }
+{ "type": "Feature", "properties": { "name": "South Hill Blvd & Chicago Way", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.428733, 37.711181 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Persia Ave & Brazil Ave", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.422639, 37.717784 ] } }
+{ "type": "Feature", "properties": { "name": "MANSELL ST & PERSIA AVE", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.423658, 37.717954 ] } }
 ,
 { "type": "Feature", "properties": { "name": "1750 Geneva Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.422832, 37.712437 ] } }
 ,
@@ -1635,33 +1719,33 @@
 ,
 { "type": "Feature", "properties": { "name": "Hahn St & Sunnydale Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.414753, 37.714720 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Raymond Ave & Elliot St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.413348, 37.712615 ] } }
+{ "type": "Feature", "properties": { "name": "Raymond Ave & Elliot St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.413477, 37.712590 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Visitacion Ave & Schwerin St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.415966, 37.709594 ] } }
+{ "type": "Feature", "properties": { "name": "Visitacion Ave & Britton St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.415537, 37.709950 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Geneva Ave & Rio Verde St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.415622, 37.707030 ] } }
+{ "type": "Feature", "properties": { "name": "Geneva Ave & Castelo St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.416556, 37.707260 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Schwerin St & Velasco Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.412608, 37.707811 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Delta St & Wilde Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.406267, 37.716859 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Raymond Ave & Delta St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.407737, 37.711962 ] } }
+{ "type": "Feature", "properties": { "name": "Raymond Ave & Delta St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.407898, 37.711919 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Leland Ave@Alpha St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.403778, 37.714338 ] } }
+{ "type": "Feature", "properties": { "name": "Raymond Ave & Alpha St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.404014, 37.714050 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Wilde Ave & Girard St", "clustered": true, "point_count": 30, "sqrt_point_count": 5.48, "point_count_abbreviated": "30" }, "geometry": { "type": "Point", "coordinates": [ -122.401707, 37.713583 ] } }
+{ "type": "Feature", "properties": { "name": "Wilde Ave & Girard St", "clustered": true, "point_count": 29, "sqrt_point_count": 5.39, "point_count_abbreviated": "29" }, "geometry": { "type": "Point", "coordinates": [ -122.401632, 37.713685 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bay Shore Blvd & Hester Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.402040, 37.711614 ] } }
+{ "type": "Feature", "properties": { "name": "Bay Shore Blvd & Visitacion Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.400677, 37.712047 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sunnydale Ave & Talbert St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.405237, 37.709034 ] } }
+{ "type": "Feature", "properties": { "name": "Sunnydale Ave & Rutland St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.405688, 37.709135 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Blanken Ave & Nueva Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.395999, 37.711079 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Ingerson Ave & Hawes St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.389498, 37.717759 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "JAMESTOWN AVE & CANDLESTICK PARK", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.388082, 37.713965 ] } }
+{ "type": "Feature", "properties": { "name": "JAMESTOWN AVE & CANDLESTICK PARK" }, "geometry": { "type": "Point", "coordinates": [ -122.388725, 37.714389 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "JAMESTOWN AVE & LANSDALE AVE" }, "geometry": { "type": "Point", "coordinates": [ -122.387942, 37.712794 ] } }
+{ "type": "Feature", "properties": { "name": "49ERS DRIVE", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.387824, 37.713430 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Alana Way & Executive Park Blvd" }, "geometry": { "type": "Point", "coordinates": [ -122.394218, 37.708983 ] } }
 ,
@@ -1697,57 +1781,63 @@
 ,
 { "type": "Feature", "properties": { "name": "Wisconsin St & Connecticut St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.397437, 37.753641 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "24th St & Sanchez St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.428046, 37.751334 ] } }
+{ "type": "Feature", "properties": { "name": "24th St & Sanchez St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.428175, 37.751664 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Church St & Clipper St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.430675, 37.746787 ] } }
+{ "type": "Feature", "properties": { "name": "Church St & Clipper St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.430192, 37.747151 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Church St & 27th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.426137, 37.749365 ] } }
 ,
 { "type": "Feature", "properties": { "name": "24th St & Guerrero St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.422167, 37.751936 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Noe St & 29th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.428808, 37.742731 ] } }
+{ "type": "Feature", "properties": { "name": "Noe St & 29th St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.428830, 37.742808 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "30th St & Church St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.428036, 37.739779 ] } }
+{ "type": "Feature", "properties": { "name": "30th St & Sanchez St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.427950, 37.740687 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Whitney St & Fairmount Street", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.426169, 37.740220 ] } }
+{ "type": "Feature", "properties": { "name": "Chenery St & Mateo St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.428111, 37.737607 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 29th St", "clustered": true, "point_count": 22, "sqrt_point_count": 4.69, "point_count_abbreviated": "22" }, "geometry": { "type": "Point", "coordinates": [ -122.423465, 37.740508 ] } }
+{ "type": "Feature", "properties": { "name": "Chenery St & 30th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.422993, 37.742010 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & Highland Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.421684, 37.744394 ] } }
+{ "type": "Feature", "properties": { "name": "Chenery St & Randall St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.424034, 37.739100 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 24th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.417886, 37.751401 ] } }
+{ "type": "Feature", "properties": { "name": "Valencia St & 24th St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.418530, 37.751766 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "26th St & South Van Ness Ave", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.419066, 37.747542 ] } }
+{ "type": "Feature", "properties": { "name": "26th St & Mission St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.419013, 37.747754 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "24th St & Folsom St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.413638, 37.751452 ] } }
+{ "type": "Feature", "properties": { "name": "Cesar Chavez St & South Van Ness Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.414271, 37.751622 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & Cesar Chavez St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.412769, 37.747711 ] } }
+{ "type": "Feature", "properties": { "name": "26th St & Folsom St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.413284, 37.749942 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Cesar Chavez St & Folsom St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.412597, 37.747601 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Mission St & 29th St" }, "geometry": { "type": "Point", "coordinates": [ -122.420644, 37.744292 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Cortland Ave & Elsie St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.418305, 37.739397 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ripley St & Folsom St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.411610, 37.743274 ] } }
+{ "type": "Feature", "properties": { "name": "Ripley St & Folsom St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.411674, 37.743681 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bernal Heights Blvd & Powhattan Ave", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.412790, 37.738998 ] } }
+{ "type": "Feature", "properties": { "name": "Nevada St & Powhattan Ave", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.412790, 37.739066 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cortland Ave & Bradford St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.425236, 37.735307 ] } }
+{ "type": "Feature", "properties": { "name": "Nevada St & Cortland Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.418337, 37.738133 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bosworth St & Marsily St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.429484, 37.730921 ] } }
+{ "type": "Feature", "properties": { "name": "Bosworth St & Rotteck St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.428637, 37.733101 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Trumbull St & Congdon St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.426383, 37.732032 ] } }
+{ "type": "Feature", "properties": { "name": "Lyell St & Alemany Blvd", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.429913, 37.729877 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Crescent Ave & Leese St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.424088, 37.731896 ] } }
+{ "type": "Feature", "properties": { "name": "Silver Ave & Lisbon St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.426405, 37.732278 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Trumbull St & Stoneybrook Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.425311, 37.727543 ] } }
+{ "type": "Feature", "properties": { "name": "Crescent Ave & Leese St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.422189, 37.735155 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Excelsior Ave & Naples St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.429774, 37.722290 ] } }
+{ "type": "Feature", "properties": { "name": "Silver Ave & Congdon St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.423615, 37.729105 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Persia Ave & Athens St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.427800, 37.720457 ] } }
+{ "type": "Feature", "properties": { "name": "Excelsior Ave & Madrid St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.429591, 37.723750 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Athens St & Avalon Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.423648, 37.725065 ] } }
+{ "type": "Feature", "properties": { "name": "Persia Ave & Naples St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.428797, 37.721179 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Brazil Ave & Prague St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.425847, 37.719694 ] } }
+{ "type": "Feature", "properties": { "name": "Persia Ave & Moscow St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.426180, 37.721425 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Felton St & Peru Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.423862, 37.723428 ] } }
+,
+{ "type": "Feature", "properties": { "name": "DUBLIN ST & BRAZIL AVE", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.425793, 37.719312 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Richland Ave & Murray St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.418423, 37.734646 ] } }
 ,
@@ -1765,19 +1855,21 @@
 ,
 { "type": "Feature", "properties": { "name": "Woolsey St & Dartmouth St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.411503, 37.722927 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mansell St & University St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.408144, 37.748314 ] } }
+{ "type": "Feature", "properties": { "name": "Mansell St & University St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.408499, 37.747694 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "C. Chavez St&Florida St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.409325, 37.748407 ] } }
+{ "type": "Feature", "properties": { "name": "25th St & Potrero Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.407554, 37.750231 ] } }
 ,
 { "type": "Feature", "properties": { "name": "228 Bay Shore Blvd", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.402565, 37.749891 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Rhode Island St & 26th St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.401643, 37.749433 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bradford St & Esmeralda Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.407179, 37.742612 ] } }
+{ "type": "Feature", "properties": { "name": "Bradford St & Esmeralda Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.407265, 37.742833 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cortland Ave & Hilton St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.407050, 37.738854 ] } }
+{ "type": "Feature", "properties": { "name": "380 Bay Shore Blvd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.407190, 37.739388 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Oakdale Ave & Loomis St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.401428, 37.742383 ] } }
+{ "type": "Feature", "properties": { "name": "Bay Shore Blvd & Cortland Ave", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.406224, 37.739439 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Oakdale Ave & Barneveld Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.401031, 37.742358 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Industrial St & Elmira St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.402083, 37.739253 ] } }
 ,
@@ -1795,9 +1887,9 @@
 ,
 { "type": "Feature", "properties": { "name": "Palou Ave & Phelps St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.393231, 37.739083 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Evans Ave & Phelps St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.389562, 37.740729 ] } }
+{ "type": "Feature", "properties": { "name": "Evans Ave & Phelps St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.389283, 37.741493 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Newhall St & Newcomb Ave", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.389433, 37.738659 ] } }
+{ "type": "Feature", "properties": { "name": "Newhall St & La Salle Ave", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.389637, 37.738438 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Bay Shore Blvd & Boutwell St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.405763, 37.732804 ] } }
 ,
@@ -1805,29 +1897,31 @@
 ,
 { "type": "Feature", "properties": { "name": "Silver Ave & Topeka Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.400495, 37.732719 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "San Bruno Ave & Bacon St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.402662, 37.728290 ] } }
+{ "type": "Feature", "properties": { "name": "San Bruno Ave & Bacon St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.402179, 37.728460 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Holyoke St & Bacon St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.408016, 37.725040 ] } }
+{ "type": "Feature", "properties": { "name": "Holyoke St & Bacon St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.408048, 37.725125 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mansell St & Dartmouth St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.406213, 37.720882 ] } }
+{ "type": "Feature", "properties": { "name": "Mansell St & Dartmouth St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.406675, 37.720092 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "San Bruno Ave & Woolsey St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.401503, 37.723962 ] } }
+{ "type": "Feature", "properties": { "name": "San Bruno Ave & Wayland St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.402244, 37.724582 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Paul Ave & Crane St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.401546, 37.721510 ] } }
+{ "type": "Feature", "properties": { "name": "Bayshore St & Paul Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.401568, 37.722367 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "San Bruno Ave & Ward St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.399057, 37.726237 ] } }
+{ "type": "Feature", "properties": { "name": "San Bruno Ave & Mansell St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.400774, 37.720865 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Topeka Ave & Venus St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.395442, 37.731489 ] } }
+{ "type": "Feature", "properties": { "name": "Topeka Ave & Bridge View Dr", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.396697, 37.732575 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Reddy St & Williams Ave", "clustered": true, "point_count": 20, "sqrt_point_count": 4.47, "point_count_abbreviated": "20" }, "geometry": { "type": "Point", "coordinates": [ -122.391998, 37.733890 ] } }
+{ "type": "Feature", "properties": { "name": "Topeka Ave & Thornton Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.393274, 37.733246 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "3rd St & Bayview St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.390753, 37.732397 ] } }
+{ "type": "Feature", "properties": { "name": "Third Street/Oakdale/Palou", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.390667, 37.733229 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Williams Ave & 3rd St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.392287, 37.728901 ] } }
+{ "type": "Feature", "properties": { "name": "3rd St & Thomas Ave", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.392620, 37.729368 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Paul Ave & Gould St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.395302, 37.724361 ] } }
+{ "type": "Feature", "properties": { "name": "Van Dyke Ave & Keith St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.392877, 37.726330 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Paul Ave & Carr St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.395903, 37.721272 ] } }
+{ "type": "Feature", "properties": { "name": "Armstrong Ave & 3rd St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.395324, 37.723835 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Third Street & Le Conte Ave", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.395828, 37.721230 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Van Dyke Ave & Jennings St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.389605, 37.725023 ] } }
 ,
@@ -1871,49 +1965,55 @@
 ,
 { "type": "Feature", "properties": { "name": "FOLSOM & BEALE" }, "geometry": { "type": "Point", "coordinates": [ -122.392813, 37.788675 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sutter St & Buchanan St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.428755, 37.785826 ] } }
+{ "type": "Feature", "properties": { "name": "Sutter St & Buchanan St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.428969, 37.785818 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Eddy St & Buchanan St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.428154, 37.781959 ] } }
+{ "type": "Feature", "properties": { "name": "Post St & Octavia St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.428250, 37.783197 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sutter St & Gough St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.422982, 37.786496 ] } }
+{ "type": "Feature", "properties": { "name": "Eddy St & Laguna St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.425901, 37.784580 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Geary Blvd", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.422553, 37.783138 ] } }
+{ "type": "Feature", "properties": { "name": "Starr King Way & Gough St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.421695, 37.785784 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Eddy St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.427371, 37.778729 ] } }
+{ "type": "Feature", "properties": { "name": "Eddy St & Gough St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.423079, 37.781222 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hayes St & Webster St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.428282, 37.776524 ] } }
+{ "type": "Feature", "properties": { "name": "Golden Gate Ave & Van Ness Ave", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.429205, 37.777440 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Haight St & Fillmore St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.428991, 37.773106 ] } }
+{ "type": "Feature", "properties": { "name": "Mcallister St & Laguna St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.428819, 37.775133 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Grove St & Octavia St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.424152, 37.776939 ] } }
+{ "type": "Feature", "properties": { "name": "Haight St & Fillmore St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.427446, 37.774124 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hayes St & Franklin St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.423712, 37.773530 ] } }
+{ "type": "Feature", "properties": { "name": "Grove St & Octavia St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.424431, 37.777185 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Page St & Franklin St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.420268, 37.782333 ] } }
+{ "type": "Feature", "properties": { "name": "Fell St & Gough St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.424023, 37.773802 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "O'Farrell St & Larkin St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.418358, 37.784597 ] } }
+{ "type": "Feature", "properties": { "name": "Page St & Gough St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.420933, 37.779712 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Turk St & Polk St", "clustered": true, "point_count": 22, "sqrt_point_count": 4.69, "point_count_abbreviated": "22" }, "geometry": { "type": "Point", "coordinates": [ -122.417511, 37.781400 ] } }
+{ "type": "Feature", "properties": { "name": "Geary Blvd & Larkin St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.417983, 37.785818 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Leavenworth St & Post St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.412812, 37.786403 ] } }
+{ "type": "Feature", "properties": { "name": "Eddy St & Van Ness Ave", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.418637, 37.782010 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ellis St & Taylor St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.413037, 37.781968 ] } }
+{ "type": "Feature", "properties": { "name": "Hyde St & Turk St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.415065, 37.784190 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Golden Gate Ave & Jones St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.414968, 37.780085 ] } }
+{ "type": "Feature", "properties": { "name": "Ellis St & Jones St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.411953, 37.785275 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Oak St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.417929, 37.776295 ] } }
+{ "type": "Feature", "properties": { "name": "Golden Gate Ave & Leavenworth St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.412136, 37.781468 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "MARKET ST & VAN NESS AVE", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.418326, 37.773827 ] } }
+{ "type": "Feature", "properties": { "name": "7th St & Market St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.418766, 37.776693 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "11th St & Howard St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.413573, 37.777991 ] } }
+{ "type": "Feature", "properties": { "name": "Larkin St & Grove St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.417704, 37.776117 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "8th St & Howard St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.412726, 37.773217 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & South Van Ness Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.417521, 37.773310 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 9th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.425632, 37.770197 ] } }
+{ "type": "Feature", "properties": { "name": "Hyde St & Fulton St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.413434, 37.778389 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "14th St & Church St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.429205, 37.767416 ] } }
+{ "type": "Feature", "properties": { "name": "8th St & Howard St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.412747, 37.773556 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Church St & 16th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.427789, 37.764795 ] } }
+{ "type": "Feature", "properties": { "name": "11th St & Harrison St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.417318, 37.772080 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Fillmore St & Deboce Ave temp bus terminal", "clustered": true, "point_count": 22, "sqrt_point_count": 4.69, "point_count_abbreviated": "22" }, "geometry": { "type": "Point", "coordinates": [ -122.429001, 37.768416 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Sanchez St & 15th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.429870, 37.765194 ] } }
+,
+{ "type": "Feature", "properties": { "name": "16th St & Dolores St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.426941, 37.765100 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Valencia St & Duboce Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.422757, 37.767509 ] } }
 ,
@@ -1925,47 +2025,55 @@
 ,
 { "type": "Feature", "properties": { "name": "18th St & Valencia St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.421470, 37.760512 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Valencia St & 21st St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.420440, 37.761691 ] } }
+{ "type": "Feature", "properties": { "name": "Valencia St & 21st St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.420493, 37.761199 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 14th St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.418605, 37.765482 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & 15th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.417715, 37.767560 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 16th St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.415740, 37.764676 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & 16th St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.417940, 37.765024 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "11th St & Harrison St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.411385, 37.768544 ] } }
+{ "type": "Feature", "properties": { "name": "South Van Ness & 18th St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.414957, 37.765431 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 18th St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.412372, 37.763845 ] } }
+{ "type": "Feature", "properties": { "name": "11th St & Bryant St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.411288, 37.768340 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 19th St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.418197, 37.759629 ] } }
+{ "type": "Feature", "properties": { "name": "Folsom St & 18th St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.410794, 37.764294 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 21st St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.418208, 37.755499 ] } }
+{ "type": "Feature", "properties": { "name": "18th St & Mission St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.418938, 37.760469 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 18th St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.412683, 37.760215 ] } }
+{ "type": "Feature", "properties": { "name": "South Van Ness & 20th St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.418283, 37.756321 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Bryant St & 20th St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.412919, 37.756915 ] } }
+{ "type": "Feature", "properties": { "name": "South Van Ness & 22nd St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.415376, 37.758315 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Powell St & Geary Blvd", "clustered": true, "point_count": 40, "sqrt_point_count": 6.32, "point_count_abbreviated": "40" }, "geometry": { "type": "Point", "coordinates": [ -122.407651, 37.785334 ] } }
+{ "type": "Feature", "properties": { "name": "Folsom St & 20St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.410827, 37.760435 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & 4th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.407093, 37.782782 ] } }
+{ "type": "Feature", "properties": { "name": "Folsom St & 22nd St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.414410, 37.755702 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "5th St & Howard St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.402834, 37.786157 ] } }
+{ "type": "Feature", "properties": { "name": "Powell St & Geary Blvd", "clustered": true, "point_count": 35, "sqrt_point_count": 5.92, "point_count_abbreviated": "35" }, "geometry": { "type": "Point", "coordinates": [ -122.407876, 37.785300 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Howard St & New Montgomery St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.400784, 37.783469 ] } }
+{ "type": "Feature", "properties": { "name": "Stockton St & Ellis St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.406889, 37.783859 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 4th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.402748, 37.780637 ] } }
+{ "type": "Feature", "properties": { "name": "5th St & Mission St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.404851, 37.784817 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "7th St & Folsom St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.406610, 37.776134 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & 3rd St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.401332, 37.785987 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "8th St & Bryant St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.405237, 37.774107 ] } }
+{ "type": "Feature", "properties": { "name": "3rd St & Folsom St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.401246, 37.782231 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "5th St & Harrison St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.401654, 37.777304 ] } }
+{ "type": "Feature", "properties": { "name": "Harrison St & 4th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.406224, 37.778025 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Folsom St & 6th St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.406245, 37.775964 ] } }
+,
+{ "type": "Feature", "properties": { "name": "8th St & Bryant St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.406020, 37.772860 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Harrison St & 5th St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.401804, 37.777906 ] } }
 ,
 { "type": "Feature", "properties": { "name": "5th St & Brannan St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.401503, 37.773030 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Townsend St & 6th St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.397566, 37.783681 ] } }
+{ "type": "Feature", "properties": { "name": "Townsend St & 6th St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.398746, 37.781408 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Folsom St & 1st St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.395924, 37.783978 ] } }
+{ "type": "Feature", "properties": { "name": "Second Street & Folsom Street", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.395817, 37.785283 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "2nd St & Bryant St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.393006, 37.783799 ] } }
+{ "type": "Feature", "properties": { "name": "Harrison St & 3rd St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.396085, 37.782137 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Brannan St & 3rd St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.392759, 37.784096 ] } }
 ,
 { "type": "Feature", "properties": { "name": "The Embarcadero & Brannan St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.389830, 37.782553 ] } }
 ,
@@ -1979,43 +2087,43 @@
 ,
 { "type": "Feature", "properties": { "name": "Third Street & Mission Rock St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.389702, 37.772513 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Potrero Ave & Alameda St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.407812, 37.767729 ] } }
+{ "type": "Feature", "properties": { "name": "Potrero Ave & Alameda St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.407715, 37.768077 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "16th St & Potrero Ave", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.406664, 37.765414 ] } }
+{ "type": "Feature", "properties": { "name": "Potrero Ave & 16th St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.406825, 37.765507 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Vermont St & Mariposa St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.403542, 37.767356 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "16th St & Kansas St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.402093, 37.765202 ] } }
+{ "type": "Feature", "properties": { "name": "16th St & Kansas St", "clustered": true, "point_count": 20, "sqrt_point_count": 4.47, "point_count_abbreviated": "20" }, "geometry": { "type": "Point", "coordinates": [ -122.402244, 37.765219 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "De Haro St & Mariposa St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.405612, 37.761233 ] } }
+{ "type": "Feature", "properties": { "name": "17th St & Wisconsin St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.404314, 37.762208 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Vermont St & 18th St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.407973, 37.757543 ] } }
+{ "type": "Feature", "properties": { "name": "Potrero Ave & 20th St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.407533, 37.758561 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Potrero Ave & 21st St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.405355, 37.757051 ] } }
+{ "type": "Feature", "properties": { "name": "Bryant St & 23rd St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.406868, 37.755236 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Vermont St & 20th St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.401890, 37.759239 ] } }
+{ "type": "Feature", "properties": { "name": "Vermont St & 19th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.402619, 37.759901 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Rhode Island St & 22nd St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.401139, 37.755583 ] } }
+{ "type": "Feature", "properties": { "name": "De Haro St & 20th St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.401814, 37.756415 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Wisconsin St & 23rd St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.397512, 37.762581 ] } }
+{ "type": "Feature", "properties": { "name": "Rhode Island St & 23rd St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.399873, 37.755974 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "7th St & 16th St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.397180, 37.764006 ] } }
+{ "type": "Feature", "properties": { "name": "16th Street & Missouri St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.396911, 37.765855 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "18th St & Texas St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.392395, 37.765592 ] } }
+{ "type": "Feature", "properties": { "name": "Connecticut St & 18th St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.395656, 37.762641 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "3rd St & Gene Friend Way", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.389251, 37.768077 ] } }
+{ "type": "Feature", "properties": { "name": "Mission Bay South & 4th St SE-FS/ BZ", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.389841, 37.768679 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "18th St & Minnesota St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.391579, 37.762785 ] } }
+{ "type": "Feature", "properties": { "name": "3rd St & 16th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.389551, 37.765804 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Missouri St & 20th St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.395892, 37.759180 ] } }
+{ "type": "Feature", "properties": { "name": "Mariposa & 3rd St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.392384, 37.762352 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Arkansas St & 22nd St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.397072, 37.755253 ] } }
+{ "type": "Feature", "properties": { "name": "Missouri St & Sierra St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.396257, 37.758086 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "14 Dakota St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.393746, 37.755745 ] } }
+{ "type": "Feature", "properties": { "name": "23rd St & Wisconsin St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.396793, 37.754879 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "20th St & 3rd St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.389380, 37.758637 ] } }
+{ "type": "Feature", "properties": { "name": "22nd St & Iowa St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.389262, 37.758934 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "3rd St & 23rd St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.388006, 37.755354 ] } }
+{ "type": "Feature", "properties": { "name": "Pennsylvania Avenue & 23rd Street", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.389401, 37.755278 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Mission St & 24th St" }, "geometry": { "type": "Point", "coordinates": [ -122.418412, 37.752733 ] } }
 ,
@@ -2047,79 +2155,87 @@
 ,
 { "type": "Feature", "properties": { "name": "Hyde St & Beach St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.419131, 37.806148 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Jefferson St & Powell St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.412093, 37.807360 ] } }
+{ "type": "Feature", "properties": { "name": "Jefferson St & Powell St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.412329, 37.807411 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Chestnut St & Laguna St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.429656, 37.801485 ] } }
+{ "type": "Feature", "properties": { "name": "North Point St & Stockton St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.425729, 37.802867 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Laguna St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.426920, 37.801951 ] } }
+{ "type": "Feature", "properties": { "name": "Chestnut St & Gough St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.428916, 37.800578 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Bay St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.423980, 37.803435 ] } }
+{ "type": "Feature", "properties": { "name": "Lombard St&Gough St SE-FS/BZ", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.425364, 37.803647 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Greenwich St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.423240, 37.798747 ] } }
+{ "type": "Feature", "properties": { "name": "Francisco Street & Polk Street", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.423862, 37.802808 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Jackson St & Buchanan St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.428701, 37.792923 ] } }
+{ "type": "Feature", "properties": { "name": "Van Ness Ave & Greenwich St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.423476, 37.799027 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sacramento St & Buchanan St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.429055, 37.790710 ] } }
+{ "type": "Feature", "properties": { "name": "Polk St & Green St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.426201, 37.795203 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Van Ness Ave & Vallejo St", "clustered": true, "point_count": 22, "sqrt_point_count": 4.69, "point_count_abbreviated": "22" }, "geometry": { "type": "Point", "coordinates": [ -122.422661, 37.794517 ] } }
+{ "type": "Feature", "properties": { "name": "Jackson St & Octavia St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.428916, 37.791668 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Polk St & Washington St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.422564, 37.791566 ] } }
+{ "type": "Feature", "properties": { "name": "Sacramento St & Octavia St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.426115, 37.792600 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Polk St & California St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.420493, 37.797814 ] } }
+{ "type": "Feature", "properties": { "name": "Jackson St & Franklin St", "clustered": true, "point_count": 25, "sqrt_point_count": 5, "point_count_abbreviated": "25" }, "geometry": { "type": "Point", "coordinates": [ -122.422768, 37.794067 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Columbus Ave & Francisco St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.417736, 37.801739 ] } }
+{ "type": "Feature", "properties": { "name": "Clay St & Franklin St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.422071, 37.791159 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hyde St & Green St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.416320, 37.801138 ] } }
+{ "type": "Feature", "properties": { "name": "Bush St &Van ness Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.420139, 37.801070 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "COLUMBUS AVE & CHESTNUT ST", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.412168, 37.802689 ] } }
+{ "type": "Feature", "properties": { "name": "Columbus Ave & Francisco St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.417672, 37.801926 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Taylor St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.411975, 37.799612 ] } }
+{ "type": "Feature", "properties": { "name": "Hyde St & Green St", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.416824, 37.800536 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Pacific Ave & Larkin St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.418294, 37.794923 ] } }
+{ "type": "Feature", "properties": { "name": "Columbus Ave & Chestnut St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.413230, 37.803045 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hyde St & Clay St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.418498, 37.791642 ] } }
+{ "type": "Feature", "properties": { "name": "Powell St & Lombard St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.412168, 37.801155 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hyde St & California St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.415601, 37.792109 ] } }
+{ "type": "Feature", "properties": { "name": "Union St & Mason St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.413273, 37.798501 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clay St & Jones St", "clustered": true, "point_count": 27, "sqrt_point_count": 5.2, "point_count_abbreviated": "27" }, "geometry": { "type": "Point", "coordinates": [ -122.411739, 37.794542 ] } }
+{ "type": "Feature", "properties": { "name": "Pacific Ave & Hyde St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.417843, 37.794398 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Clay St & Leavenworth St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.418509, 37.791134 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Sacramento St & Leavenworth St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.415204, 37.792355 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Washington St & Taylor St", "clustered": true, "point_count": 26, "sqrt_point_count": 5.1, "point_count_abbreviated": "26" }, "geometry": { "type": "Point", "coordinates": [ -122.411631, 37.794593 ] } }
 ,
 { "type": "Feature", "properties": { "name": "California St & Taylor St", "clustered": true, "point_count": 10, "sqrt_point_count": 3.16, "point_count_abbreviated": "10" }, "geometry": { "type": "Point", "coordinates": [ -122.412994, 37.790015 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Sutter St & Mason St" }, "geometry": { "type": "Point", "coordinates": [ -122.410312, 37.789065 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "The Embarcadero & Grant St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.407469, 37.807063 ] } }
+{ "type": "Feature", "properties": { "name": "The Embarcadero & Grant St", "clustered": true, "point_count": 5, "sqrt_point_count": 2.24, "point_count_abbreviated": "5" }, "geometry": { "type": "Point", "coordinates": [ -122.408252, 37.807224 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "The Embarcadero & Bay St" }, "geometry": { "type": "Point", "coordinates": [ -122.405430, 37.806614 ] } }
+{ "type": "Feature", "properties": { "name": "The Embarcadero & Bay St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.405988, 37.806749 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Lombard St & Stockton St", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.407672, 37.802875 ] } }
+{ "type": "Feature", "properties": { "name": "Lombard St & Stockton St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.407951, 37.802918 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "TELEGRAPH Hill Blvd & Filbert St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.407812, 37.799620 ] } }
+{ "type": "Feature", "properties": { "name": "TELEGRAPH Hill Blvd & Greenwich St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.407823, 37.799841 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Union St & Montgomery St", "clustered": true, "point_count": 15, "sqrt_point_count": 3.87, "point_count_abbreviated": "15" }, "geometry": { "type": "Point", "coordinates": [ -122.404926, 37.800205 ] } }
+{ "type": "Feature", "properties": { "name": "Union St & Kearny St", "clustered": true, "point_count": 16, "sqrt_point_count": 4, "point_count_abbreviated": "16" }, "geometry": { "type": "Point", "coordinates": [ -122.405183, 37.800154 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Battery St & Greenwich St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.401353, 37.802341 ] } }
+{ "type": "Feature", "properties": { "name": "Sansome St & Filbert St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.401578, 37.802341 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Battery St & Green St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.401750, 37.798527 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Pacific Ave & Stockton St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.407726, 37.794593 ] } }
+{ "type": "Feature", "properties": { "name": "Pacific Ave & Stockton St", "clustered": true, "point_count": 17, "sqrt_point_count": 4.12, "point_count_abbreviated": "17" }, "geometry": { "type": "Point", "coordinates": [ -122.407908, 37.794584 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clay St & Grant Ave", "clustered": true, "point_count": 32, "sqrt_point_count": 5.66, "point_count_abbreviated": "32" }, "geometry": { "type": "Point", "coordinates": [ -122.407533, 37.791413 ] } }
+{ "type": "Feature", "properties": { "name": "Kearny St & Clay St", "clustered": true, "point_count": 30, "sqrt_point_count": 5.48, "point_count_abbreviated": "30" }, "geometry": { "type": "Point", "coordinates": [ -122.407469, 37.791753 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "California St & Grant Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.403982, 37.792719 ] } }
+{ "type": "Feature", "properties": { "name": "Stockton St & Sutter St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.405913, 37.790328 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Sacramento St & Montgomery St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.401106, 37.793643 ] } }
+{ "type": "Feature", "properties": { "name": "Washington St & Sansome St", "clustered": true, "point_count": 18, "sqrt_point_count": 4.24, "point_count_abbreviated": "18" }, "geometry": { "type": "Point", "coordinates": [ -122.401546, 37.794025 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Kearny St & Bush St", "clustered": true, "point_count": 27, "sqrt_point_count": 5.2, "point_count_abbreviated": "27" }, "geometry": { "type": "Point", "coordinates": [ -122.401149, 37.790091 ] } }
+{ "type": "Feature", "properties": { "name": "California St & Battery St", "clustered": true, "point_count": 30, "sqrt_point_count": 5.48, "point_count_abbreviated": "30" }, "geometry": { "type": "Point", "coordinates": [ -122.400988, 37.790405 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Broadway & Davis St", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.397416, 37.798696 ] } }
 ,
 { "type": "Feature", "properties": { "name": "The Embarcadero & Washington St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.395613, 37.797145 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Clay St & Drumm St", "clustered": true, "point_count": 46, "sqrt_point_count": 6.78, "point_count_abbreviated": "46" }, "geometry": { "type": "Point", "coordinates": [ -122.395624, 37.793982 ] } }
+{ "type": "Feature", "properties": { "name": "Clay St & Drumm St", "clustered": true, "point_count": 39, "sqrt_point_count": 6.24, "point_count_abbreviated": "39" }, "geometry": { "type": "Point", "coordinates": [ -122.395957, 37.793982 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Mission St & Spear St", "clustered": true, "point_count": 24, "sqrt_point_count": 4.9, "point_count_abbreviated": "24" }, "geometry": { "type": "Point", "coordinates": [ -122.395560, 37.791532 ] } }
+{ "type": "Feature", "properties": { "name": "Steuart St & Mission St", "clustered": true, "point_count": 30, "sqrt_point_count": 5.48, "point_count_abbreviated": "30" }, "geometry": { "type": "Point", "coordinates": [ -122.395173, 37.792075 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Main St & Howard St", "clustered": true, "point_count": 21, "sqrt_point_count": 4.58, "point_count_abbreviated": "21" }, "geometry": { "type": "Point", "coordinates": [ -122.393661, 37.790803 ] } }
+{ "type": "Feature", "properties": { "name": "Mission St & Spear St", "clustered": true, "point_count": 19, "sqrt_point_count": 4.36, "point_count_abbreviated": "19" }, "geometry": { "type": "Point", "coordinates": [ -122.393972, 37.790566 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Steuart St&Mission St", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.391933, 37.792829 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Howard St & Spear St", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.391311, 37.790812 ] } }
 ,
@@ -2173,21 +2289,25 @@
 ,
 { "type": "Feature", "properties": { "name": "Newhall St & Fairfax Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.384530, 37.742010 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hudson Ave & Mendell St", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.384219, 37.738803 ] } }
+{ "type": "Feature", "properties": { "name": "Hudson Ave & Mendell St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.384230, 37.738956 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Fairfax Ave & Keith St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.380282, 37.737827 ] } }
+{ "type": "Feature", "properties": { "name": "Hudson Ave & Keith St" }, "geometry": { "type": "Point", "coordinates": [ -122.384155, 37.737590 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Cashmere St & La Salle Ave", "clustered": true, "point_count": 14, "sqrt_point_count": 3.74, "point_count_abbreviated": "14" }, "geometry": { "type": "Point", "coordinates": [ -122.385625, 37.733449 ] } }
+{ "type": "Feature", "properties": { "name": "Fairfax Ave & Keith St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.380421, 37.737938 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Whitney Young Cir & Progress St", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.384874, 37.730547 ] } }
+{ "type": "Feature", "properties": { "name": "Middle Point Rd & West Point Rd" }, "geometry": { "type": "Point", "coordinates": [ -122.379316, 37.737013 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Oakdale Ave & Ingalls St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.381548, 37.732100 ] } }
+{ "type": "Feature", "properties": { "name": "Cashmere St & La Salle Ave", "clustered": true, "point_count": 12, "sqrt_point_count": 3.46, "point_count_abbreviated": "12" }, "geometry": { "type": "Point", "coordinates": [ -122.385764, 37.733526 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Hudson Ave & Ingalls St", "clustered": true, "point_count": 11, "sqrt_point_count": 3.32, "point_count_abbreviated": "11" }, "geometry": { "type": "Point", "coordinates": [ -122.379498, 37.732592 ] } }
+{ "type": "Feature", "properties": { "name": "Newcomb Ave & La Salle Ave", "clustered": true, "point_count": 8, "sqrt_point_count": 2.83, "point_count_abbreviated": "8" }, "geometry": { "type": "Point", "coordinates": [ -122.384938, 37.731667 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Oakdale Ave & Baldwin Ct", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.379402, 37.729478 ] } }
+{ "type": "Feature", "properties": { "name": "Ingalls St & Thomas Ave", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.383983, 37.728918 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Ingalls St & Van Dyke Ave", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.386397, 37.726423 ] } }
+{ "type": "Feature", "properties": { "name": "Middle Point Rd & West Point Rd", "clustered": true, "point_count": 13, "sqrt_point_count": 3.61, "point_count_abbreviated": "13" }, "geometry": { "type": "Point", "coordinates": [ -122.379917, 37.733602 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Innes Ave & Hunters Point Blvd", "clustered": true, "point_count": 9, "sqrt_point_count": 3, "point_count_abbreviated": "9" }, "geometry": { "type": "Point", "coordinates": [ -122.380024, 37.730607 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Northridge Rd & Harbor Rd", "clustered": true, "point_count": 6, "sqrt_point_count": 2.45, "point_count_abbreviated": "6" }, "geometry": { "type": "Point", "coordinates": [ -122.382106, 37.728086 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Innes Ave & Griffith St", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.375743, 37.731998 ] } }
 ,
@@ -2197,7 +2317,9 @@
 ,
 { "type": "Feature", "properties": { "name": "SPEAR ST & COCHRANE ST", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.368319, 37.725329 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "ROBINSON ST/Bldg 152", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.364306, 37.728154 ] } }
+{ "type": "Feature", "properties": { "name": "ROBINSON ST/Bldg 152", "clustered": true, "point_count": 3, "sqrt_point_count": 1.73, "point_count_abbreviated": "3" }, "geometry": { "type": "Point", "coordinates": [ -122.365412, 37.728417 ] } }
+,
+{ "type": "Feature", "properties": { "name": "Lockwood St & Bldg 214" }, "geometry": { "type": "Point", "coordinates": [ -122.360981, 37.727348 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Gilman Ave & Griffith St" }, "geometry": { "type": "Point", "coordinates": [ -122.388275, 37.718234 ] } }
 ] }
@@ -2239,11 +2361,11 @@
 { "type": "FeatureCollection", "properties": { "layer": "muni", "version": 2, "extent": 4096 }, "features": [
 { "type": "Feature", "properties": { "name": "Gateview Ave & Mason Ct", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.377310, 37.827565 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Gateview Ave & Bayside Dr", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.373168, 37.829099 ] } }
+{ "type": "Feature", "properties": { "name": "Gateview Ave & Bayside Dr", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.374359, 37.829828 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "Avenue B & 12th St", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.374746, 37.824048 ] } }
+{ "type": "Feature", "properties": { "name": "13th St & Gateview Ave", "clustered": true, "point_count": 7, "sqrt_point_count": 2.65, "point_count_abbreviated": "7" }, "geometry": { "type": "Point", "coordinates": [ -122.374370, 37.825353 ] } }
 ,
-{ "type": "Feature", "properties": { "name": "9th St & Avenue E", "clustered": true, "point_count": 2, "sqrt_point_count": 1.41, "point_count_abbreviated": "2" }, "geometry": { "type": "Point", "coordinates": [ -122.370540, 37.826930 ] } }
+{ "type": "Feature", "properties": { "name": "9th St & Avenue D", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.371924, 37.825362 ] } }
 ,
 { "type": "Feature", "properties": { "name": "Avenue M & 10th St", "clustered": true, "point_count": 4, "sqrt_point_count": 2, "point_count_abbreviated": "4" }, "geometry": { "type": "Point", "coordinates": [ -122.369306, 37.825336 ] } }
 ,

--- a/tile.cpp
+++ b/tile.cpp
@@ -1875,7 +1875,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			unsigned long long sfindex = sf.index;
 
 			if (sf.geometry.size() > 0) {
-				if (lead_features_count > max_tile_size) {
+				if (lead_features_count > max_tile_size || (lead_features_count + other_multiplier_cluster_features_count > max_tile_features && !prevent[P_FEATURE_LIMIT])) {
 					// Even being maximally conservative, each feature is still going to be
 					// at least one byte in the output tile, so this can't possibly work.
 					skipped++;

--- a/tile.cpp
+++ b/tile.cpp
@@ -2110,33 +2110,35 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				tasks = 1;
 			}
 
-			pthread_t pthreads[tasks];
-			std::vector<simplification_worker_arg> args;
-			args.resize(tasks);
-			for (int i = 0; i < tasks; i++) {
-				args[i].task = i;
-				args[i].tasks = tasks;
-				args[i].features = &features;
-				args[i].shared_nodes = &shared_nodes;
-				args[i].shared_nodes_map = shared_nodes_map;
-				args[i].nodepos = nodepos;
+			{
+				pthread_t pthreads[tasks];
+				std::vector<simplification_worker_arg> args;
+				args.resize(tasks);
+				for (int i = 0; i < tasks; i++) {
+					args[i].task = i;
+					args[i].tasks = tasks;
+					args[i].features = &features;
+					args[i].shared_nodes = &shared_nodes;
+					args[i].shared_nodes_map = shared_nodes_map;
+					args[i].nodepos = nodepos;
+
+					if (tasks > 1) {
+						if (thread_create(&pthreads[i], NULL, simplification_worker, &args[i]) != 0) {
+							perror("pthread_create");
+							exit(EXIT_PTHREAD);
+						}
+					} else {
+						simplification_worker(&args[i]);
+					}
+				}
 
 				if (tasks > 1) {
-					if (thread_create(&pthreads[i], NULL, simplification_worker, &args[i]) != 0) {
-						perror("pthread_create");
-						exit(EXIT_PTHREAD);
-					}
-				} else {
-					simplification_worker(&args[i]);
-				}
-			}
+					for (int i = 0; i < tasks; i++) {
+						void *retval;
 
-			if (tasks > 1) {
-				for (int i = 0; i < tasks; i++) {
-					void *retval;
-
-					if (pthread_join(pthreads[i], &retval) != 0) {
-						perror("pthread_join");
+						if (pthread_join(pthreads[i], &retval) != 0) {
+							perror("pthread_join");
+						}
 					}
 				}
 			}
@@ -2304,8 +2306,6 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				layer.features.push_back(std::move(feature));
 				layer_features[x] = serial_feature();
 			}
-
-			printf("tile_stringpool: %zu\n", tile_stringpool->size());
 
 			if (layer.features.size() > 0) {
 				tile.layers.push_back(std::move(layer));

--- a/tile.cpp
+++ b/tile.cpp
@@ -2261,6 +2261,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				}
 
 				if (layer_features[x].geometry.size() == 0) {
+					layer_features[x] = serial_feature();
 					continue;
 				}
 
@@ -2301,7 +2302,10 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				}
 
 				layer.features.push_back(std::move(feature));
+				layer_features[x] = serial_feature();
 			}
+
+			printf("tile_stringpool: %zu\n", tile_stringpool->size());
 
 			if (layer.features.size() > 0) {
 				tile.layers.push_back(std::move(layer));

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.52.0"
+#define VERSION "v2.53.0"
 
 #endif


### PR DESCRIPTION
This PR makes two changes to Tippecanoe to reduce memory consumption:

1. As features are converted to `mvt_feature` to add them to the output tile, erase their `serial_feature` representation
2. When the number of features scheduled to be included in the tile reaches the maximum feature count, don't wait any longer to start finding features to drop