### PR TITLE
Minor dockerfile optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ CMD make test
 # Using multistage build reduces the docker image size by alot by only copying the needed binaries
 FROM ubuntu:22.04
 RUN apt-get update \
-  && apt-get -y install libsqlite3-dev zlib1g-dev \
+  && apt-get -y install libsqlite3-0 \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=tippecanoe-builder /tmp/tippecanoe-src/tippecanoe* /usr/local/bin/
 COPY --from=tippecanoe-builder /tmp/tippecanoe-src/tile-join /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04 AS tippecanoe-builder
 
 RUN apt-get update \
-  && apt-get -y install build-essential libsqlite3-dev zlib1g-dev
+  && apt-get -y install make gcc g++ libsqlite3-dev zlib1g-dev
 
 COPY . /tmp/tippecanoe-src
 WORKDIR /tmp/tippecanoe-src

--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ uses md2man (`gem install md2man`).
 
 Linux:
 
-    sudo apt-get install build-essential libsqlite3-dev zlib1g-dev
+    sudo apt-get install gcc g++ make libsqlite3-dev zlib1g-dev
 
 Then build:
 


### PR DESCRIPTION
Micro-optimizations for the Docker images. In the builder image we don't need all of build-essential, that is for package maintainers. We also don't need to install -dev packages in the final image, because we don't need headers and docs. Net result is slightly snappier build the first time, and a 25% reduction in final image size.