### PR TITLE
Fix latitude bboxes for features that extend beyond the mercator plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.59.0
+
+* Correct `antimeridian_adjusted_bounds` latitude calculation when vertices extend beyond the edge of the Mercator plane
+
 # 2.58.0
 
 * Add --generate-variable-depth-tile-pyramid option

--- a/serial.cpp
+++ b/serial.cpp
@@ -423,12 +423,15 @@ int serialize_feature(struct serialization_state *sst, serial_feature &sf, std::
 
 	for (size_t i = 0; i < sf.geometry.size(); i++) {
 		if (sf.geometry[i].op == VT_MOVETO || sf.geometry[i].op == VT_LINETO) {
-			if (sf.geometry[i].y > 0 && sf.geometry[i].y < 0xFFFFFFFF) {
-				// standard -180 to 180 world plane
+			// standard -180 to 180 world plane
+			//
+			// mask X, since it wraps around
+			// pin Y, since it doesn't
 
-				long long x = sf.geometry[i].x & 0xFFFFFFFF;
-				long long y = sf.geometry[i].y & 0xFFFFFFFF;
+			long long x = sf.geometry[i].x & 0xFFFFFFFF;
+			long long y = std::max(std::min(sf.geometry[i].y, 0xFFFFFFFFLL), 0LL);
 
+			{
 				r->file_bbox1[0] = std::min(r->file_bbox1[0], x);
 				r->file_bbox1[1] = std::min(r->file_bbox1[1], y);
 				r->file_bbox1[2] = std::max(r->file_bbox1[2], x);

--- a/tests/accumulate/out/--set-attribute_thecomma%3aNEWVALUE_--accumulate-attribute_thecomma%3acomma.json
+++ b/tests/accumulate/out/--set-attribute_thecomma%3aNEWVALUE_--accumulate-attribute_thecomma%3acomma.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
+"antimeridian_adjusted_bounds": "3.757458,-85.051129,359.744029,85.051129",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "-179.320808,-69.033211,14",
 "description": "tests/accumulate/out/--set-attribute_thecomma%3aNEWVALUE_--accumulate-attribute_thecomma%3acomma.json.check.mbtiles",

--- a/tests/accumulate/out/-z0_--set-attribute_%7b%22num%22%3a5,%22str%22%3a%22abc%22}.json
+++ b/tests/accumulate/out/-z0_--set-attribute_%7b%22num%22%3a5,%22str%22%3a%22abc%22}.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
+"antimeridian_adjusted_bounds": "3.757458,-85.051129,359.744029,85.051129",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/accumulate/out/-z0_--set-attribute_%7b%22num%22%3a5,%22str%22%3a%22abc%22}.json.check.mbtiles",

--- a/tests/accumulate/out/-z0_--set-attribute_num%3a5_--set-attribute_str%3aabc.json
+++ b/tests/accumulate/out/-z0_--set-attribute_num%3a5_--set-attribute_str%3aabc.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
+"antimeridian_adjusted_bounds": "3.757458,-85.051129,359.744029,85.051129",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/accumulate/out/-z0_--set-attribute_num%3a5_--set-attribute_str%3aabc.json.check.mbtiles",

--- a/tests/accumulate/out/-z3_--accumulate-attribute_%7b%22thesum%22%3a%22sum%22,%22theproduct%22%3a%22product%22}.json
+++ b/tests/accumulate/out/-z3_--accumulate-attribute_%7b%22thesum%22%3a%22sum%22,%22theproduct%22%3a%22product%22}.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
+"antimeridian_adjusted_bounds": "3.757458,-85.051129,359.744029,85.051129",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "-157.500000,20.489949,3",
 "description": "tests/accumulate/out/-z3_--accumulate-attribute_%7b%22thesum%22%3a%22sum%22,%22theproduct%22%3a%22product%22}.json.check.mbtiles",

--- a/tests/accumulate/out/-z3_-Ethesum%3asum_-Etheproduct%3aproduct_-Ethemax%3amax_-Ethemin%3amin_-Ethemean%3amean_-Etheconcat%3aconcat_-Ethecomma%3acomma_-r1_-K100.json
+++ b/tests/accumulate/out/-z3_-Ethesum%3asum_-Etheproduct%3aproduct_-Ethemax%3amax_-Ethemin%3amin_-Ethemean%3amean_-Etheconcat%3aconcat_-Ethecomma%3acomma_-r1_-K100.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
+"antimeridian_adjusted_bounds": "3.757458,-85.051129,359.744029,85.051129",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "112.500000,20.489949,3",
 "description": "tests/accumulate/out/-z3_-Ethesum%3asum_-Etheproduct%3aproduct_-Ethemax%3amax_-Ethemin%3amin_-Ethemean%3amean_-Etheconcat%3aconcat_-Ethecomma%3acomma_-r1_-K100.json.check.mbtiles",

--- a/tests/accumulate/out/-z5_-Ethesum%3asum_-Etheproduct%3aproduct_-Ethemax%3amax_-Ethemin%3amin_-Ethemean%3amean_-Etheconcat%3aconcat_-Ethecomma%3acomma.json
+++ b/tests/accumulate/out/-z5_-Ethesum%3asum_-Etheproduct%3aproduct_-Ethemax%3amax_-Ethemin%3amin_-Ethemean%3amean_-Etheconcat%3aconcat_-Ethecomma%3acomma.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "3.757458,-84.969764,359.744029,85.007238",
+"antimeridian_adjusted_bounds": "3.757458,-85.051129,359.744029,85.051129",
 "bounds": "-179.320808,-85.051129,177.449262,85.051129",
 "center": "-174.375000,-52.349536,5",
 "description": "tests/accumulate/out/-z5_-Ethesum%3asum_-Etheproduct%3aproduct_-Ethemax%3amax_-Ethemin%3amin_-Ethemean%3amean_-Etheconcat%3aconcat_-Ethecomma%3acomma.json.check.mbtiles",

--- a/tests/coalesce-id/out/-z1_--coalesce_--reorder.json
+++ b/tests/coalesce-id/out/-z1_--coalesce_--reorder.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023803,-85.040752,359.950215,83.645130",
+"antimeridian_adjusted_bounds": "0.023803,-85.051129,359.950215,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "90.000000,42.525564,1",
 "description": "tests/coalesce-id/out/-z1_--coalesce_--reorder.json.check.mbtiles",

--- a/tests/csv/out-null.mbtiles.json
+++ b/tests/csv/out-null.mbtiles.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "-175.220564,-41.299988,179.216647,64.150024",
+"antimeridian_adjusted_bounds": "-175.220564,-41.299988,179.216647,85.051129",
 "bounds": "-180.000000,-41.299988,180.000000,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/csv/out-null.mbtiles",

--- a/tests/csv/out.mbtiles.json
+++ b/tests/csv/out.mbtiles.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "-175.220564,-41.299988,179.216647,64.150024",
+"antimeridian_adjusted_bounds": "-175.220564,-41.299988,179.216647,85.051129",
 "bounds": "-180.000000,-41.299988,180.000000,85.051129",
 "center": "0.000000,0.000000,0",
 "description": "tests/csv/out.mbtiles",

--- a/tests/invalid-polygon/out/-z0.json
+++ b/tests/invalid-polygon/out/-z0.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "180.000000,85.051129,-180.000000,-85.051129",
+"antimeridian_adjusted_bounds": "-135.232962,-85.051129,-135.232962,-85.051129",
 "bounds": "-135.232962,-85.051129,-135.232962,-85.051129",
 "center": "-135.232962,-85.051129,0",
 "description": "tests/invalid-polygon/out/-z0.json.check.mbtiles",

--- a/tests/join-population/empty.out.json
+++ b/tests/join-population/empty.out.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "180.000000,85.051129,-180.000000,-85.051129",
+"antimeridian_adjusted_bounds": "0.000000,-85.051129,0.000000,-85.051129",
 "bounds": "-180.000000,-85.051129,180.000000,-85.051129",
 "center": "0.000000,-85.051129,0",
 "format": "pbf",

--- a/tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json
+++ b/tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_admin_0_countries/out/--coalesce_-z2_-Ccat.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-B10_-z0_--retain-points-multiplier_10_-d8_-yNAME.json
+++ b/tests/ne_110m_admin_0_countries/out/-B10_-z0_--retain-points-multiplier_10_-d8_-yNAME.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-B10_-z0_--retain-points-multiplier_10_-d8_-yNAME.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-R5%2f17%2f11.json
+++ b/tests/ne_110m_admin_0_countries/out/-R5%2f17%2f11.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-R5%2f17%2f11.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-densest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-fraction-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--force-feature-limit.json
+++ b/tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--force-feature-limit.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-ae_-zg_-M5000_--force-feature-limit.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-110.039063,26.980829,-92.021484,51.998410",
 "center": "-92.021484,26.980829,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--clip-bounding-box_-110,27,-92,52.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--order-largest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--order-smallest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_100.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--order-largest-first.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json
+++ b/tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-z0_--tiny-polygon-size_50_--simplification_50.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z1_-yname_--no-simplification-of-shared-nodes.json
+++ b/tests/ne_110m_admin_0_countries/out/-z1_-yname_--no-simplification-of-shared-nodes.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "90.000000,42.525564,1",
 "description": "tests/ne_110m_admin_0_countries/out/-z1_-yname_--no-simplification-of-shared-nodes.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json
+++ b/tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "45.000000,33.256630,2",
 "description": "tests/ne_110m_admin_0_countries/out/-z2_--convert-polygons-to-label-points.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z3_-ai.json
+++ b/tests/ne_110m_admin_0_countries/out/-z3_-ai.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "22.500000,20.489949,3",
 "description": "tests/ne_110m_admin_0_countries/out/-z3_-ai.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--drop-polygons.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--grid-low-zooms_-D8.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_--no-tiny-polygon-reduction.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--simplification-at-maximum-zoom_2.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "11.250000,48.378236,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-S4_--visvalingam.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json
+++ b/tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "-101.250000,70.266402,4",
 "description": "tests/ne_110m_admin_0_countries/out/-z4_-yname_-pD.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-densest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-fraction-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--coalesce-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json
+++ b/tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "16.875000,44.951199,5",
 "description": "tests/ne_110m_admin_0_countries/out/-z5_-M5000_--drop-smallest-as-needed.json.check.mbtiles",

--- a/tests/ne_110m_admin_0_countries/out/-zg_-yname.json
+++ b/tests/ne_110m_admin_0_countries/out/-zg_-yname.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "0.023802,-85.040752,359.950216,83.645130",
+"antimeridian_adjusted_bounds": "0.023802,-85.051129,359.950216,83.645130",
 "bounds": "-180.000000,-85.051129,180.000000,83.645130",
 "center": "0.000000,0.000000,0",
 "description": "tests/ne_110m_admin_0_countries/out/-zg_-yname.json.check.mbtiles",

--- a/tests/raw-tiles/nothing.json
+++ b/tests/raw-tiles/nothing.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "180.000000,85.051129,-180.000000,-85.051129",
+"antimeridian_adjusted_bounds": "0.000000,85.051129,0.000000,85.051129",
 "bounds": "-180.000000,85.051129,180.000000,85.051129",
 "center": "-179.989014,85.051129,14",
 "description": "tests/raw-tiles/nothing",

--- a/tests/wraparound2/out/-z0_--detect-longitude-wraparound.json
+++ b/tests/wraparound2/out/-z0_--detect-longitude-wraparound.json
@@ -1,5 +1,5 @@
 { "type": "FeatureCollection", "properties": {
-"antimeridian_adjusted_bounds": "-180.000000,12.583700,179.688000,85.027900",
+"antimeridian_adjusted_bounds": "-180.000000,12.583700,179.688000,85.051129",
 "bounds": "-180.000000,12.583700,180.000000,85.051129",
 "center": "0.000000,12.583700,0",
 "description": "tests/wraparound2/out/-z0_--detect-longitude-wraparound.json.check.mbtiles",

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.58.0"
+#define VERSION "v2.59.0"
 
 #endif


### PR DESCRIPTION
Only vertices within the mercator plane were being taken into account when setting the latitude bounds in the `antimeridian_adjusted_bounding_box`, even though features can actually extend into the buffer past the edge to get closer to the poles.