### PR TITLE
Remove buggy optimization to avoid reclipping in overzoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.65.5
+# 2.62.6
+
+* Remove buggy optimization to avoid reclipping in tippecanoe-overzoom
+
+# 2.62.5
 
 * More aggressive binning when points fail the point-in-polygon test
 

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ overzoom-test: tippecanoe-overzoom
 	cmp tests/pbf/13-1310-3166.pbf.json.check tests/pbf/13-1310-3166.pbf.json
 	rm tests/pbf/13-1310-3166.pbf tests/pbf/13-1310-3166.pbf.json.check
 	# Make sure feature order is stable
-	./tippecanoe-overzoom --preserve-input-order -o tests/pbf/11-327-791-out.pbf tests/pbf/11-327-791.pbf 11/327/791 11/327/791
+	./tippecanoe-overzoom -b20 --preserve-input-order -o tests/pbf/11-327-791-out.pbf tests/pbf/11-327-791.pbf 11/327/791 11/327/791
 	./tippecanoe-decode tests/pbf/11-327-791.pbf 11 327 791 > tests/pbf/11-327-791.json
 	./tippecanoe-decode tests/pbf/11-327-791-out.pbf 11 327 791 > tests/pbf/11-327-791-out.json
 	cmp tests/pbf/11-327-791.json tests/pbf/11-327-791-out.json

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,7 @@ overzoom-test: tippecanoe-overzoom
 	cmp tests/pbf/13-1310-3166.pbf.json.check tests/pbf/13-1310-3166.pbf.json
 	rm tests/pbf/13-1310-3166.pbf tests/pbf/13-1310-3166.pbf.json.check
 	# Make sure feature order is stable
+	# Large -b20 tile buffer to prevent altering the geometries by clipping
 	./tippecanoe-overzoom -b20 --preserve-input-order -o tests/pbf/11-327-791-out.pbf tests/pbf/11-327-791.pbf 11/327/791 11/327/791
 	./tippecanoe-decode tests/pbf/11-327-791.pbf 11 327 791 > tests/pbf/11-327-791.json
 	./tippecanoe-decode tests/pbf/11-327-791-out.pbf 11 327 791 > tests/pbf/11-327-791-out.json

--- a/clip.cpp
+++ b/clip.cpp
@@ -1725,7 +1725,7 @@ std::string overzoom(std::vector<source_tile> const &tiles, int nz, int nx, int 
 				}
 
 				// Don't clip here if we are binning, because we need to bin points in the buffer
-				if (!sametile && bins.size() == 0) {
+				if (bins.size() == 0) {
 					// Clip to output tile
 
 					long long xmin = LLONG_MAX;

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.62.5"
+#define VERSION "v2.62.6"
 
 #endif


### PR DESCRIPTION
There was a special case to avoid spending time clipping the geometries when the output zxy was the same as the input zxy, but it also prevented clipping in the cases where I *wanted* clipping to happen and was calling tippecanoe-overzoom specifically to do it.