### PR TITLE
Add github workflow to build container images on repo tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build Images
+
+on:
+  push:
+    tags: ["*"]
+  # Allow manual trigger for retroactive builds
+  workflow_dispatch:
+
+env:
+    # Use docker.io for Docker Hub if empty
+    REGISTRY: ghcr.io
+    # github.repository as <account>/<repo>
+    IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            # Login against a Docker registry
+            # https://github.com/docker/login-action
+            - name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            # Extract metadata (tags, labels) for Docker
+            # https://github.com/docker/metadata-action
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            # Setup QEMU emulator to build multi-arch images
+            # https://github.com/docker/setup-qemu-action
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            # Configure Buildx for Docker build
+            # https://github.com/docker/setup-buildx-action
+            - name: Set up Buildx
+              uses: docker/setup-buildx-action@v3
+
+            # Build and push Docker image with Buildx
+            # https://github.com/docker/build-push-action
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: 'linux/amd64,linux/arm64'


### PR DESCRIPTION
Fixes #167

## Issue

- A few users are requesting pre-built container images on GHCR, myself included 😄 
- It's a low effort small win, to aid distribution of tippecanoe.

## Solution

- Add a Github workflow to build the container image whenever a new tag is made on this repo.
- The image will be tagged and labelled to match the repo tag.
- The image will be multi-architecture: AMD64 + ARM64.

> [!NOTE]
> If this PR is accepted, a small change could be made to the README referencing the images (instead of requiring the user to build themselves).