### PR TITLE
Raise tippecanoe-decode tile size limit to 250 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.70.1
+
+* Raise tippecanoe-decode limit on the size of individual tiles
+
 # 2.70.0
 
 * Performance improvements to tippecanoe-overzoom with attribute exclusion

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.70.0"
+#define VERSION "v2.70.1"
 
 #endif


### PR DESCRIPTION
Tippecanoe-decode had a 50 MB limit on the size of single tiles to decode, I think to keep it from risking trying to read an entire mbtiles file into memory to try to decode it as a tile. But I am now running into a tile larger than 50 MB that I need to decode. So this PR raises the limit to 250 MB and gives a clearer message if that limit is ever exceeded.