### PR TITLE
Refactor various filesystem related operations to use std::filesystem

### DIFF
--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -121,7 +121,6 @@ void check_dir(const char *dir, char **argv, bool force, bool forcetable) {
 		std::string fn = std::string(dir) + "/" + tiles[i].path();
 
 		if (force) {
-			std::error_code ec;
 			fs::remove(fn, ec);
 			if (ec) {
 				perror(fn.c_str());

--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -9,7 +9,6 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <limits.h>
-#include <sys/stat.h>
 #include <sqlite3.h>
 #include "jsonpull/jsonpull.h"
 #include "mbtiles.hpp"

--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -100,7 +100,7 @@ void check_dir(const char *dir, char **argv, bool force, bool forcetable) {
 	fs::permissions(dir, fs::perms::all, fs::perm_options::add, ec);
 	std::string meta = fs::path(dir) / "metadata.json";
 	if (force) {
-		unlink(meta.c_str());  // error OK since it may not exist;
+		fs::remove(meta, ec);  // error OK since it may not exist
 	} else {
 		if (fs::exists(meta)) {
 			fprintf(stderr, "%s: Tileset \"%s\" already exists. You can use --force if you want to delete the old tileset.\n", argv[0], dir);
@@ -122,7 +122,9 @@ void check_dir(const char *dir, char **argv, bool force, bool forcetable) {
 		std::string fn = std::string(dir) + "/" + tiles[i].path();
 
 		if (force) {
-			if (unlink(fn.c_str()) != 0) {
+			std::error_code ec;
+			fs::remove(fn, ec);
+			if (ec) {
 				perror(fn.c_str());
 				exit(EXIT_UNLINK);
 			}
@@ -219,7 +221,9 @@ void dir_erase_zoom(const char *fname, int zoom) {
 						while ((dp3 = readdir(d3)) != NULL) {
 							if (pbfname(dp3->d_name)) {
 								std::string y = x + "/" + dp3->d_name;
-								if (unlink(y.c_str()) != 0) {
+								std::error_code ec;
+								fs::remove(y, ec);
+								if (ec) {
 									perror(y.c_str());
 									exit(EXIT_UNLINK);
 								}

--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -16,6 +17,8 @@
 #include "errors.hpp"
 #include "write_json.hpp"
 
+namespace fs = std::filesystem;
+
 std::string dir_read_tile(std::string base, struct zxy tile) {
 	std::ifstream pbfFile(base + "/" + tile.path(), std::ios::in | std::ios::binary);
 	std::ostringstream contents;
@@ -26,40 +29,43 @@ std::string dir_read_tile(std::string base, struct zxy tile) {
 }
 
 void dir_write_tile(const char *outdir, int z, int tx, int ty, std::string const &pbf) {
-	// Don't check mkdir error returns, since most of these calls to
-	// mkdir will be creating directories that already exist.
-	mkdir(outdir, S_IRWXU | S_IRWXG | S_IRWXO);
+	fs::path dirPath(outdir);
+	fs::path zPath = dirPath / std::to_string(z);
+	fs::path xPath = zPath / std::to_string(tx);
+	fs::path tilePath = xPath / (std::to_string(ty) + ".pbf");
 
-	std::string curdir(outdir);
-	std::string slash("/");
+	// create_directories() does not treat a directory already existing
+	// as an error, which is fine since most directories will already exist.
+	std::error_code ec;
+	fs::create_directories(xPath, ec);
+	if (ec) {
+		fprintf(stderr, "Failed to create directories: %s\n", ec.message().c_str());
+		exit(EXIT_WRITE);
+	}
 
-	std::string newdir = curdir + slash + std::to_string(z);
-	mkdir(newdir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+	// Set permissions equivalent to S_IRWXU | S_IRWXG | S_IRWXO (0777)
+	fs::permissions(dirPath, fs::perms::all, fs::perm_options::add, ec);
+	fs::permissions(zPath, fs::perms::all, fs::perm_options::add, ec);
+	fs::permissions(xPath, fs::perms::all, fs::perm_options::add, ec);
 
-	newdir = newdir + "/" + std::to_string(tx);
-	mkdir(newdir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
-
-	newdir = newdir + "/" + std::to_string(ty) + ".pbf";
-
-	struct stat st;
-	if (stat(newdir.c_str(), &st) == 0) {
-		fprintf(stderr, "Can't write tile to already existing %s\n", newdir.c_str());
+	if (fs::exists(tilePath)) {
+		fprintf(stderr, "Can't write tile to already existing %s\n", tilePath.c_str());
 		exit(EXIT_EXISTS);
 	}
 
-	FILE *fp = fopen(newdir.c_str(), "wb");
+	FILE *fp = fopen(tilePath.c_str(), "wb");
 	if (fp == NULL) {
-		fprintf(stderr, "%s: %s\n", newdir.c_str(), strerror(errno));
+		fprintf(stderr, "%s: %s\n", tilePath.c_str(), strerror(errno));
 		exit(EXIT_WRITE);
 	}
 
 	if (fwrite(pbf.c_str(), sizeof(char), pbf.size(), fp) != pbf.size()) {
-		fprintf(stderr, "%s: %s\n", newdir.c_str(), strerror(errno));
+		fprintf(stderr, "%s: %s\n", tilePath.c_str(), strerror(errno));
 		exit(EXIT_WRITE);
 	}
 
 	if (fclose(fp) != 0) {
-		fprintf(stderr, "%s: %s\n", newdir.c_str(), strerror(errno));
+		fprintf(stderr, "%s: %s\n", tilePath.c_str(), strerror(errno));
 		exit(EXIT_CLOSE);
 	}
 }
@@ -85,14 +91,18 @@ static bool pbfname(const char *s) {
 }
 
 void check_dir(const char *dir, char **argv, bool force, bool forcetable) {
-	struct stat st;
-
-	mkdir(dir, S_IRWXU | S_IRWXG | S_IRWXO);
-	std::string meta = std::string(dir) + "/" + "metadata.json";
+	std::error_code ec;
+	fs::create_directories(dir, ec);
+	if (ec) {
+		fprintf(stderr, "Failed to create directory: %s\n", ec.message().c_str());
+		exit(EXIT_WRITE);
+	}
+	fs::permissions(dir, fs::perms::all, fs::perm_options::add, ec);
+	std::string meta = fs::path(dir) / "metadata.json";
 	if (force) {
 		unlink(meta.c_str());  // error OK since it may not exist;
 	} else {
-		if (stat(meta.c_str(), &st) == 0) {
+		if (fs::exists(meta)) {
 			fprintf(stderr, "%s: Tileset \"%s\" already exists. You can use --force if you want to delete the old tileset.\n", argv[0], dir);
 			fprintf(stderr, "%s: %s: file exists\n", argv[0], meta.c_str());
 			if (!forcetable) {
@@ -288,8 +298,7 @@ static void out(json_writer &state, std::string k, std::string v) {
 void dir_write_metadata(const char *outdir, const metadata &m) {
 	std::string metadata = std::string(outdir) + "/metadata.json";
 
-	struct stat st;
-	if (stat(metadata.c_str(), &st) == 0) {
+	if (fs::exists(metadata)) {
 		// Leave existing metadata in place with --allow-existing
 	} else {
 		FILE *fp = fopen(metadata.c_str(), "w");

--- a/geojson.cpp
+++ b/geojson.cpp
@@ -7,7 +7,6 @@
 #include <math.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>

--- a/main.cpp
+++ b/main.cpp
@@ -755,37 +755,35 @@ void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int split
 	for (i = 0; i < splits; i++) {
 		sub_geompos[i] = 0;
 
-		char geomname[strlen(tmpdir) + strlen("/geom.XXXXXXXX") + 1];
-		snprintf(geomname, sizeof(geomname), "%s%s", tmpdir, "/geom.XXXXXXXX");
-		char indexname[strlen(tmpdir) + strlen("/index.XXXXXXXX") + 1];
-		snprintf(indexname, sizeof(indexname), "%s%s", tmpdir, "/index.XXXXXXXX");
+		std::string geomname = std::string(tmpdir) + "/geom.XXXXXXXX";
+		std::string indexname = std::string(tmpdir) + "/index.XXXXXXXX";
 
-		geomfds[i] = mkstemp_cloexec(geomname);
+		geomfds[i] = mkstemp_cloexec(geomname.data());
 		if (geomfds[i] < 0) {
-			perror(geomname);
+			perror(geomname.c_str());
 			exit(EXIT_OPEN);
 		}
-		indexfds[i] = mkstemp_cloexec(indexname);
+		indexfds[i] = mkstemp_cloexec(indexname.data());
 		if (indexfds[i] < 0) {
-			perror(indexname);
+			perror(indexname.c_str());
 			exit(EXIT_OPEN);
 		}
 
-		geomfiles[i] = fopen_oflag(geomname, "wb", O_WRONLY | O_CLOEXEC);
+		geomfiles[i] = fopen_oflag(geomname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 		if (geomfiles[i] == NULL) {
-			perror(geomname);
+			perror(geomname.c_str());
 			exit(EXIT_OPEN);
 		}
-		indexfiles[i] = fopen_oflag(indexname, "wb", O_WRONLY | O_CLOEXEC);
+		indexfiles[i] = fopen_oflag(indexname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 		if (indexfiles[i] == NULL) {
-			perror(indexname);
+			perror(indexname.c_str());
 			exit(EXIT_OPEN);
 		}
 
 		*availfiles -= 4;
 
-		unlink(geomname);
-		unlink(indexname);
+		fs::remove(geomname);
+		fs::remove(indexname);
 	}
 
 	for (i = 0; i < inputs; i++) {
@@ -1222,79 +1220,74 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 	for (size_t i = 0; i < CPUS; i++) {
 		struct reader *r = &readers[i];
 
-		char poolname[strlen(tmpdir) + strlen("/pool.XXXXXXXX") + 1];
-		char treename[strlen(tmpdir) + strlen("/tree.XXXXXXXX") + 1];
-		char geomname[strlen(tmpdir) + strlen("/geom.XXXXXXXX") + 1];
-		char indexname[strlen(tmpdir) + strlen("/index.XXXXXXXX") + 1];
-		char vertexname[strlen(tmpdir) + strlen("/vertex.XXXXXXXX") + 1];
-		char nodename[strlen(tmpdir) + strlen("/node.XXXXXXXX") + 1];
+		std::string poolname = std::string(tmpdir) + "/pool.XXXXXXXX";
+		std::string treename = std::string(tmpdir) + "/tree.XXXXXXXX";
+		std::string geomname = std::string(tmpdir) + "/geom.XXXXXXXX";
+		std::string indexname = std::string(tmpdir) + "/index.XXXXXXXX";
+		std::string vertexname = std::string(tmpdir) + "/vertex.XXXXXXXX";
+		std::string nodename = std::string(tmpdir) + "/node.XXXXXXXX";
 
-		snprintf(poolname, sizeof(poolname), "%s%s", tmpdir, "/pool.XXXXXXXX");
-		snprintf(treename, sizeof(treename), "%s%s", tmpdir, "/tree.XXXXXXXX");
-		snprintf(geomname, sizeof(geomname), "%s%s", tmpdir, "/geom.XXXXXXXX");
-		snprintf(indexname, sizeof(indexname), "%s%s", tmpdir, "/index.XXXXXXXX");
-		snprintf(vertexname, sizeof(vertexname), "%s%s", tmpdir, "/vertex.XXXXXXXX");
-		snprintf(nodename, sizeof(nodename), "%s%s", tmpdir, "/node.XXXXXXXX");
-
-		r->poolfd = mkstemp_cloexec(poolname);
+		// Since C++11, the returned array from data() is null-terminated
+		r->poolfd = mkstemp_cloexec(poolname.data());
 		if (r->poolfd < 0) {
-			perror(poolname);
+			perror(poolname.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->treefd = mkstemp_cloexec(treename);
+		r->treefd = mkstemp_cloexec(treename.data());
 		if (r->treefd < 0) {
-			perror(treename);
+			perror(treename.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->geomfd = mkstemp_cloexec(geomname);
+		r->geomfd = mkstemp_cloexec(geomname.data());
 		if (r->geomfd < 0) {
-			perror(geomname);
+			perror(geomname.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->indexfd = mkstemp_cloexec(indexname);
+		r->indexfd = mkstemp_cloexec(indexname.data());
 		if (r->indexfd < 0) {
-			perror(indexname);
+			perror(indexname.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->vertexfd = mkstemp_cloexec(vertexname);
+		r->vertexfd = mkstemp_cloexec(vertexname.data());
 		if (r->vertexfd < 0) {
-			perror(vertexname);
+			perror(vertexname.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->nodefd = mkstemp_cloexec(nodename);
+		r->nodefd = mkstemp_cloexec(nodename.data());
 		if (r->nodefd < 0) {
-			perror(nodename);
+			perror(nodename.c_str());
 			exit(EXIT_OPEN);
 		}
 
 		r->poolfile = memfile_open(r->poolfd);
 		if (r->poolfile == NULL) {
-			perror(poolname);
+			perror(poolname.c_str());
 			exit(EXIT_OPEN);
 		}
 		r->treefile = memfile_open(r->treefd);
 		if (r->treefile == NULL) {
-			perror(treename);
+			perror(treename.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->geomfile = fopen_oflag(geomname, "wb", O_WRONLY | O_CLOEXEC);
+		r->geomfile = fopen_oflag(geomname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 		if (r->geomfile == NULL) {
-			perror(geomname);
+			perror(geomname.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->indexfile = fopen_oflag(indexname, "wb", O_WRONLY | O_CLOEXEC);
+		r->indexfile = fopen_oflag(indexname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 		if (r->indexfile == NULL) {
-			perror(indexname);
+			perror(indexname.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->vertexfile = fopen_oflag(vertexname, "w+b", O_RDWR | O_CLOEXEC);
+		r->vertexfile = fopen_oflag(vertexname.c_str(), "w+b", O_RDWR | O_CLOEXEC);
 		if (r->vertexfile == NULL) {
-			perror(("open vertexfile " + std::string(vertexname)).c_str());
+			std::string err = "open vertexfile " + vertexname;
+			perror(err.c_str());
 			exit(EXIT_OPEN);
 		}
-		r->nodefile = fopen_oflag(nodename, "w+b", O_RDWR | O_CLOEXEC);
+		r->nodefile = fopen_oflag(nodename.c_str(), "w+b", O_RDWR | O_CLOEXEC);
 		if (r->nodefile == NULL) {
-			perror(nodename);
+			perror(nodename.c_str());
 			exit(EXIT_OPEN);
 		}
 		r->geompos = 0;
@@ -1302,12 +1295,13 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		r->vertexpos = 0;
 		r->nodepos = 0;
 
-		unlink(poolname);
-		unlink(treename);
-		unlink(geomname);
-		unlink(indexname);
-		unlink(vertexname);
-		unlink(nodename);
+		fs::remove(poolname);
+		fs::remove(treename);
+		fs::remove(geomname);
+		fs::remove(indexname);
+		fs::remove(vertexname);
+		fs::remove(nodename);
+
 
 		// To distinguish a null value
 		{
@@ -1717,19 +1711,18 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 			if (read_parallel_this) {
 				// Serial reading of chunks that are then parsed in parallel
 
-				char readname[strlen(tmpdir) + strlen("/read.XXXXXXXX") + 1];
-				snprintf(readname, sizeof(readname), "%s%s", tmpdir, "/read.XXXXXXXX");
-				int readfd = mkstemp_cloexec(readname);
+				std::string readname = std::string(tmpdir) + "/read.XXXXXXXX";
+				int readfd = mkstemp_cloexec(readname.data());
 				if (readfd < 0) {
-					perror(readname);
+					perror(readname.c_str());
 					exit(EXIT_OPEN);
 				}
 				FILE *readfp = fdopen(readfd, "w");
 				if (readfp == NULL) {
-					perror(readname);
+					perror(readname.c_str());
 					exit(EXIT_OPEN);
 				}
-				unlink(readname);
+				fs::remove(readname);
 
 				std::atomic<int> is_parsing(0);
 				long long ahead = 0;
@@ -1771,18 +1764,18 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 							checkdisk(&readers);
 							ahead = 0;
 
-							snprintf(readname, sizeof(readname), "%s%s", tmpdir, "/read.XXXXXXXX");
-							readfd = mkstemp_cloexec(readname);
+							readname = std::string(tmpdir) + "/read.XXXXXXXX";
+							readfd = mkstemp_cloexec(readname.data());
 							if (readfd < 0) {
-								perror(readname);
+								perror(readname.c_str());
 								exit(EXIT_OPEN);
 							}
 							readfp = fdopen(readfd, "w");
 							if (readfp == NULL) {
-								perror(readname);
+								perror(readname.c_str());
 								exit(EXIT_OPEN);
 							}
-							unlink(readname);
+							fs::remove(readname);
 						}
 					}
 				}
@@ -1915,22 +1908,21 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		pool_off[i] = 0;
 	}
 
-	char poolname[strlen(tmpdir) + strlen("/pool.XXXXXXXX") + 1];
-	snprintf(poolname, sizeof(poolname), "%s%s", tmpdir, "/pool.XXXXXXXX");
+	std::string poolname = std::string(tmpdir) + "/pool.XXXXXXXX";
 
-	int poolfd = mkstemp_cloexec(poolname);
+	int poolfd = mkstemp_cloexec(poolname.data());
 	if (poolfd < 0) {
-		perror(poolname);
+		perror(poolname.c_str());
 		exit(EXIT_OPEN);
 	}
 
-	FILE *poolfile = fopen_oflag(poolname, "wb", O_WRONLY | O_CLOEXEC);
+	FILE *poolfile = fopen_oflag(poolname.data(), "wb", O_WRONLY | O_CLOEXEC);
 	if (poolfile == NULL) {
-		perror(poolname);
+		perror(poolname.c_str());
 		exit(EXIT_OPEN);
 	}
 
-	unlink(poolname);
+	fs::remove(poolname);
 	std::atomic<long long> poolpos(0);
 
 	for (size_t i = 0; i < CPUS; i++) {
@@ -2002,12 +1994,13 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 	// find nodes where the same central point is part of two different vertices
 	{
 		std::string tmpname = std::string(tmpdir) + "/vertex2.XXXXXX";
-		int vertexfd = mkstemp((char *) tmpname.c_str());
+		int vertexfd = mkstemp(tmpname.data());
 		if (vertexfd < 0) {
-			perror(("mkstemp vertexfile " + std::string(tmpname)).c_str());
+			std::string err = "mkstemp vertexfile " + tmpname;
+			perror(err.c_str());
 			exit(EXIT_OPEN);
 		}
-		unlink(tmpname.c_str());
+		fs::remove(tmpname);
 		FILE *vertex_out = fdopen(vertexfd, "w+b");
 		if (vertex_out == NULL) {
 			perror(tmpname.c_str());
@@ -2069,12 +2062,13 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		// sort
 
 		std::string tmpname = std::string(tmpdir) + "/node2.XXXXXX";
-		int nodefd = mkstemp((char *) tmpname.c_str());
+		int nodefd = mkstemp(tmpname.data());
 		if (nodefd < 0) {
-			perror(("mkstemp nodefile " + std::string(tmpname)).c_str());
+			std::string err = "mkstemp nodefile " + tmpname;
+			perror(tmpname.c_str());
 			exit(EXIT_OPEN);
 		}
-		unlink(tmpname.c_str());
+		fs::remove(tmpname);
 		FILE *node_out;
 		node_out = fdopen(nodefd, "w+b");
 		if (node_out == NULL) {
@@ -2102,12 +2096,13 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		// scan
 
 		tmpname = std::string(tmpdir) + "/node3.XXXXXX";
-		nodefd = mkstemp((char *) tmpname.c_str());
+		nodefd = mkstemp(tmpname.data());
 		if (nodefd < 0) {
-			perror(("mkstemp nodefile " + std::string(tmpname)).c_str());
+			std::string err = "mkstemp nodefile " + tmpname;
+			perror(tmpname.c_str());
 			exit(EXIT_OPEN);
 		}
-		unlink(tmpname.c_str());
+		fs::remove(tmpname);
 		shared_nodes = fdopen(nodefd, "w+b");
 		if (shared_nodes == NULL) {
 			perror(tmpname.c_str());
@@ -2158,36 +2153,34 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		fprintf(stderr, "Merging index                 \r");
 	}
 
-	char indexname[strlen(tmpdir) + strlen("/index.XXXXXXXX") + 1];
-	snprintf(indexname, sizeof(indexname), "%s%s", tmpdir, "/index.XXXXXXXX");
+	std::string indexname = std::string(tmpdir) + "/index.XXXXXXXX";
 
-	int indexfd = mkstemp_cloexec(indexname);
+	int indexfd = mkstemp_cloexec(indexname.data());
 	if (indexfd < 0) {
-		perror(indexname);
+		perror(indexname.c_str());
 		exit(EXIT_OPEN);
 	}
-	FILE *indexfile = fopen_oflag(indexname, "wb", O_WRONLY | O_CLOEXEC);
+	FILE *indexfile = fopen_oflag(indexname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 	if (indexfile == NULL) {
-		perror(indexname);
+		perror(indexname.c_str());
 		exit(EXIT_OPEN);
 	}
 
-	unlink(indexname);
+	fs::remove(indexname);
 
-	char geomname[strlen(tmpdir) + strlen("/geom.XXXXXXXX") + 1];
-	snprintf(geomname, sizeof(geomname), "%s%s", tmpdir, "/geom.XXXXXXXX");
+	std::string geomname = std::string(tmpdir) + "/geom.XXXXXXXX";
 
-	int geomfd = mkstemp_cloexec(geomname);
+	int geomfd = mkstemp_cloexec(geomname.data());
 	if (geomfd < 0) {
-		perror(geomname);
+		perror(geomname.c_str());
 		exit(EXIT_CLOSE);
 	}
-	FILE *geomfile = fopen_oflag(geomname, "wb", O_WRONLY | O_CLOEXEC);
+	FILE *geomfile = fopen_oflag(geomname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 	if (geomfile == NULL) {
-		perror(geomname);
+		perror(geomname.c_str());
 		exit(EXIT_OPEN);
 	}
-	unlink(geomname);
+	fs::remove(geomname);
 
 	unsigned iz = 0, ix = 0, iy = 0;
 	choose_first_zoom(file_bbox, file_bbox1, file_bbox2, readers, &iz, &ix, &iy, minzoom, buffer);
@@ -3790,7 +3783,7 @@ int main(int argc, char **argv) {
 
 	if (out_mbtiles != NULL) {
 		if (force) {
-			unlink(out_mbtiles);
+			fs::remove(out_mbtiles);
 		} else {
 			if (pmtiles_has_suffix(out_mbtiles)) {
 				check_pmtiles(out_mbtiles, argv, forcetable);

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
 #include <signal.h>
 #include <sys/time.h>
 #include <zlib.h>
+#include <filesystem>
 #include <algorithm>
 #include <vector>
 #include <string>
@@ -67,6 +68,8 @@
 #include "attribute.hpp"
 #include "thread.hpp"
 #include "platform.hpp"
+
+namespace fs = std::filesystem;
 
 static int low_detail = 12;
 static int full_detail = -1;
@@ -2991,7 +2994,8 @@ int main(int argc, char **argv) {
 	double droprate = 2.5;
 	double gamma = 0;
 	int buffer = 5;
-	const char *tmpdir = "/tmp";
+	std::string tmpdir_path = fs::temp_directory_path().string();
+	const char *tmpdir = tmpdir_path.c_str();
 	const char *attribution = NULL;
 	std::vector<source> sources;
 	const char *prefilter = NULL;

--- a/main.cpp
+++ b/main.cpp
@@ -134,7 +134,7 @@ void checkdisk(std::vector<struct reader> *r) {
 
 	static int warned = 0;
 	if (used > diskfree * .9 && !warned) {
-		fprintf(stderr, "You will probably run out of disk space.\n%lld bytes used or committed, of %lld originally available\n", used, diskfree);
+		fprintf(stderr, "You will probably run out of disk space.\n%lld bytes used or committed, of %ju originally available\n", used, diskfree);
 		warned = 1;
 	}
 };

--- a/main.cpp
+++ b/main.cpp
@@ -121,7 +121,7 @@ size_t CPUS;
 size_t TEMP_FILES;
 long long MAX_FILES;
 size_t memsize;
-static long long diskfree;
+static uintmax_t diskfree;
 char **av;
 
 std::vector<clipbbox> clipbboxes;
@@ -1323,13 +1323,13 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		r->file_bbox[2] = r->file_bbox[3] = 0;
 	}
 
-	struct statfs fsstat;
-	if (fstatfs(readers[0].geomfd, &fsstat) != 0) {
-		perror("Warning: fstatfs");
+	std::error_code ec;
+	fs::space_info si = fs::space(fs::path(tmpdir), ec);
+	if (ec) {
 		fprintf(stderr, "Tippecanoe cannot check whether disk space will run out during tiling.\n");
-		diskfree = LLONG_MAX;
+		diskfree = UINTMAX_MAX;
 	} else {
-		diskfree = (long long) fsstat.f_bsize * fsstat.f_bavail;
+		diskfree = si.available;
 	}
 
 	std::atomic<long long> progress_seq(0);

--- a/main.cpp
+++ b/main.cpp
@@ -38,9 +38,6 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/param.h>
-#include <sys/mount.h>
-#else
-#include <sys/statfs.h>
 #endif
 
 #include "jsonpull/jsonpull.h"

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -13,7 +13,6 @@
 #include <string>
 #include <set>
 #include <map>
-#include <sys/stat.h>
 #include "mvt.hpp"
 #include "mbtiles.hpp"
 #include "text.hpp"

--- a/pmtiles_file.cpp
+++ b/pmtiles_file.cpp
@@ -1,5 +1,6 @@
 #include <unordered_map>
 #include <vector>
+#include <filesystem>
 #include <fstream>
 #include <string.h>
 #include <algorithm>
@@ -11,6 +12,8 @@
 #include "mvt.hpp"
 #include "write_json.hpp"
 #include "main.hpp"
+
+namespace fs = std::filesystem;
 
 bool pmtiles_has_suffix(const char *filename) {
 	if (filename == nullptr) {
@@ -27,8 +30,7 @@ bool pmtiles_has_suffix(const char *filename) {
 }
 
 void check_pmtiles(const char *filename, char **argv, bool forcetable) {
-	struct stat st;
-	if (stat(filename, &st) == 0) {
+	if (fs::exists(filename)) {
 		fprintf(stderr, "%s: Tileset \"%s\" already exists. You can use --force if you want to delete the old tileset.\n", argv[0], filename);
 		fprintf(stderr, "%s: %s: file exists\n", argv[0], filename);
 

--- a/pmtiles_file.cpp
+++ b/pmtiles_file.cpp
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <algorithm>
 #include <unistd.h>
-#include <sys/stat.h>
 #include <sqlite3.h>
 #include "errors.hpp"
 #include "pmtiles_file.hpp"

--- a/pmtiles_file.cpp
+++ b/pmtiles_file.cpp
@@ -332,7 +332,7 @@ void mbtiles_map_image_to_pmtiles(char *fname, metadata m, bool tile_compression
 		ostream << tmp_istream.rdbuf();
 
 		tmp_istream.close();
-		unlink(tmpname.c_str());
+		fs::remove(tmpname);
 		ostream.close();
 	}
 }

--- a/sort.cpp
+++ b/sort.cpp
@@ -1,8 +1,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <filesystem>
 #include <vector>
 #include <string>
+
+namespace fs = std::filesystem;
 
 #define MAX_MEMORY (1024 * 1024 * 1024)	 // 1 GB
 
@@ -70,10 +73,10 @@ void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, 
 		std::string t1 = "/tmp/sort1.XXXXXX";
 		std::string t2 = "/tmp/sort2.XXXXXX";
 
-		int fd1 = mkstemp((char *) t1.c_str());
-		unlink(t1.c_str());
-		int fd2 = mkstemp((char *) t2.c_str());
-		unlink(t2.c_str());
+		int fd1 = mkstemp(t1.data());
+		fs::remove(t1);
+		int fd2 = mkstemp(t2.data());
+		fs::remove(t2);
 
 		fp1 = fdopen(fd1, "w+b");
 		if (fp1 == NULL) {

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -1724,7 +1724,7 @@ int main(int argc, char **argv) {
 
 	if (out_mbtiles != NULL) {
 		if (force) {
-			unlink(out_mbtiles);
+			fs::remove(out_mbtiles);
 		} else {
 			if (pmtiles_has_suffix(out_mbtiles)) {
 				check_pmtiles(out_mbtiles, argv, false);

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -38,12 +38,15 @@
 #include <sstream>
 #include <algorithm>
 #include <functional>
+#include <filesystem>
 #include "jsonpull/jsonpull.h"
 #include "milo/dtoa_milo.h"
 #include "errors.hpp"
 #include "geometry.hpp"
 #include "thread.hpp"
 #include "platform.hpp"
+
+namespace fs = std::filesystem;
 
 int pk = false;
 int pC = false;
@@ -643,8 +646,7 @@ struct tileset_reader {
 
 	tileset_reader(const char *fname) {
 		name = fname;
-		struct stat st;
-		if (stat(fname, &st) == 0 && (st.st_mode & S_IFDIR) != 0) {
+		if (fs::is_directory(fname)) {
 			db = NULL;
 			stmt = NULL;
 			next = NULL;
@@ -653,7 +655,7 @@ struct tileset_reader {
 			dirbase = fname;
 		} else if (pmtiles_has_suffix(fname)) {
 			int pmtiles_fd = open(fname, O_RDONLY | O_CLOEXEC);
-			pmtiles_map = (char *) mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, pmtiles_fd, 0);
+			pmtiles_map = (char *) mmap(NULL, fs::file_size(fname), PROT_READ, MAP_PRIVATE, pmtiles_fd, 0);
 
 			if (pmtiles_map == MAP_FAILED) {
 				perror("mmap in decode");

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -7,7 +7,6 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tile.cpp
+++ b/tile.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 #include <string>
 #include <stack>
 #include <vector>
@@ -55,14 +56,13 @@ extern "C" {
 
 #include "plugin.hpp"
 
+namespace fs = std::filesystem;
+
 #define CMD_BITS 3
 
 // Offset coordinates to keep them positive
 #define COORD_OFFSET (4LL << 32)
 #define SHIFT_RIGHT(a) ((long long) std::round((double) (a) / (1LL << geometry_scale)))
-
-#define XSTRINGIFY(s) STRINGIFY(s)
-#define STRINGIFY(s) #s
 
 pthread_mutex_t db_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t var_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -3065,23 +3065,22 @@ int traverse_zooms(int *geomfd, off_t *geom_size, char *global_stringpool, std::
 		std::atomic<long long> subpos[TEMP_FILES];
 		int subfd[TEMP_FILES];
 		for (size_t j = 0; j < TEMP_FILES; j++) {
-			char geomname[strlen(tmpdir) + strlen("/geom.XXXXXXXX" XSTRINGIFY(INT_MAX)) + 1];
-			snprintf(geomname, sizeof(geomname), "%s/geom%zu.XXXXXXXX", tmpdir, j);
-			subfd[j] = mkstemp_cloexec(geomname);
+			std::string geomname = std::string(tmpdir) + "/geom" + std::to_string(j) + ".XXXXXXXX";
+			subfd[j] = mkstemp_cloexec(geomname.data());
 			// printf("%s\n", geomname);
 			if (subfd[j] < 0) {
-				perror(geomname);
+				perror(geomname.c_str());
 				exit(EXIT_OPEN);
 			}
-			FILE *fp = fopen_oflag(geomname, "wb", O_WRONLY | O_CLOEXEC);
+			FILE *fp = fopen_oflag(geomname.c_str(), "wb", O_WRONLY | O_CLOEXEC);
 			if (fp == NULL) {
-				perror(geomname);
+				perror(geomname.c_str());
 				exit(EXIT_OPEN);
 			}
 			compressors[j] = compressor(fp);
 			sub[j] = &compressors[j];
 			subpos[j] = 0;
-			unlink(geomname);
+			fs::remove(geomname);
 		}
 
 		size_t useful_threads = 0;

--- a/unit.cpp
+++ b/unit.cpp
@@ -8,6 +8,9 @@
 #include "geometry.hpp"
 #include <unistd.h>
 #include <limits.h>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 TEST_CASE("UTF-8 enforcement", "[utf8]") {
 	REQUIRE(check_utf8("") == std::string(""));
@@ -55,8 +58,8 @@ TEST_CASE("External quicksort", "fqsort") {
 	size_t written = 0;
 	for (size_t i = 0; i < 5; i++) {
 		std::string tmpname = "/tmp/in.XXXXXXX";
-		int fd = mkstemp((char *) tmpname.c_str());
-		unlink(tmpname.c_str());
+		int fd = mkstemp(tmpname.data());
+		fs::remove(tmpname);
 		FILE *f = fdopen(fd, "w+b");
 		inputs.emplace_back(f);
 		size_t iterations = 2000 + rand() % 200;
@@ -69,8 +72,8 @@ TEST_CASE("External quicksort", "fqsort") {
 	}
 
 	std::string tmpname = "/tmp/out.XXXXXX";
-	int fd = mkstemp((char *) tmpname.c_str());
-	unlink(tmpname.c_str());
+	int fd = mkstemp(tmpname.data());
+	fs::remove(tmpname);
 	FILE *f = fdopen(fd, "w+b");
 
 	fqsort(inputs, sizeof(int), intcmp, f, 256);


### PR DESCRIPTION
This change makes use of the std::filesystem API introduced in C++17, and replaces a few instances where variable length arrays and snprintf were being used to construct temporary file paths with std::string (several other places were already using std::string). Using std::filesystem should be a bit more portable than the POSIX function calls that were previously used, which could help get a working native/MinGW build on Windows.

* Remove `#include <sys/stat.h>` from files where it is no longer needed
* Use std::filesystem functions to check free disk space available, create directories, if a path exists, if a path is a directory, and file sizes
* Use std::filesystem::remove instead of unlink (behavior on POSIX should be identical)
* Use std::string data() method to get a mutable char *, instead of casting away the const-ness of c_str() (since C++11, the array returned by data() is null-terminated)
* Replace use of VLAs for temporary file path construction with std::string
* Replace hard-coded use of `/tmp` for temporary directory with call to std::filesystem -- on Linux/macOS this returns `/tmp` by default unless the user sets an environment variable to override it (`TMPDIR`, `TMP`, `TEMP`, `TEMPDIR`), and on Windows this returns the same thing as [GetTempPath](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw)