### PR TITLE
Add macOS CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,18 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         version: ['Release', 'Debug']
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install libsqlite3-dev
+      - name: Install dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libsqlite3-dev
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install sqlite3
       - run: uname -a; BUILDTYPE=${{ matrix.version }} make
       - run: make test


### PR DESCRIPTION
Same as the Linux CI jobs, but macOS -- something to help make sure that changes are actually portable and don't break builds or tests on macOS.

The macOS release build configuration is pretty fast (in my initial run, it finished a minute before the Ubuntu release build), though the debug build on macOS was quite a bit slower (~2 minutes longer than the Ubuntu debug build).

If desired, the workflow triggers could be changed to only run the jobs for PRs and commits to main to keep the number of jobs on each commit to a minimum.