### PR TITLE
Consolidate code for getting platform details into one place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ C = $(wildcard *.c) $(wildcard *.cpp)
 INCLUDES = -I/usr/local/include -I. -Iclipper2/include
 LIBS = -L/usr/local/lib
 
-tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o serial.o main.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o
+tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-enumerate: enumerate.o
@@ -68,7 +68,7 @@ tippecanoe-enumerate: enumerate.o
 tippecanoe-decode: decode.o projection.o mvt.o write_json.o text.o jsonpull/jsonpull.o dirtiles.o pmtiles_file.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3
 
-tile-join: tile-join.o projection.o mbtiles.o mvt.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o pmtiles_file.o clip.o attribute.o thread.o read_json.o clipper2/src/clipper.engine.o
+tile-join: tile-join.o platform.o projection.o mbtiles.o mvt.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o pmtiles_file.o clip.o attribute.o thread.o read_json.o clipper2/src/clipper.engine.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-json-tool: jsontool.o jsonpull/jsonpull.o csv.o text.o geojson-loop.o

--- a/platform.cpp
+++ b/platform.cpp
@@ -1,0 +1,56 @@
+#include "platform.hpp"
+#include <cstdlib>
+#include <cstdio>
+#include <unistd.h>
+#include <sys/resource.h>
+
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
+
+#include "errors.hpp"
+
+long get_num_avail_cpus() {
+	return sysconf(_SC_NPROCESSORS_ONLN);
+}
+
+long get_page_size() {
+	return sysconf(_SC_PAGESIZE);
+}
+
+size_t calc_memsize() {
+	size_t mem;
+
+#ifdef __APPLE__
+	int64_t hw_memsize;
+	size_t len = sizeof(int64_t);
+	if (sysctlbyname("hw.memsize", &hw_memsize, &len, NULL, 0) < 0) {
+		perror("sysctl hw.memsize");
+		exit(EXIT_MEMORY);
+	}
+	mem = hw_memsize;
+#else
+	long long pagesize = sysconf(_SC_PAGESIZE);
+	long long pages = sysconf(_SC_PHYS_PAGES);
+	if (pages < 0 || pagesize < 0) {
+		perror("sysconf _SC_PAGESIZE or _SC_PHYS_PAGES");
+		exit(EXIT_MEMORY);
+	}
+
+	mem = (long long) pages * pagesize;
+#endif
+
+	return mem;
+}
+
+size_t get_max_open_files() {
+	struct rlimit rl;
+	if (getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+		perror("getrlimit");
+		exit(EXIT_PTHREAD);
+	}
+	return rl.rlim_cur;
+}

--- a/platform.hpp
+++ b/platform.hpp
@@ -1,0 +1,16 @@
+#ifndef PLATFORM_HPP
+#define PLATFORM_HPP
+
+#include <cstddef>
+
+long get_num_avail_cpus();
+
+long get_page_size();
+
+size_t calc_memsize();
+
+size_t get_max_open_files();
+
+constexpr const char *get_null_device() { return "/dev/null"; }
+
+#endif // PLATFORM_HPP

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -43,6 +43,7 @@
 #include "errors.hpp"
 #include "geometry.hpp"
 #include "thread.hpp"
+#include "platform.hpp"
 
 int pk = false;
 int pC = false;
@@ -1199,7 +1200,7 @@ int main(int argc, char **argv) {
 
 	struct tileset_reader *readers = NULL;
 
-	CPUS = sysconf(_SC_NPROCESSORS_ONLN);
+	CPUS = get_num_avail_cpus();
 
 	const char *TIPPECANOE_MAX_THREADS = getenv("TIPPECANOE_MAX_THREADS");
 	if (TIPPECANOE_MAX_THREADS != NULL) {


### PR DESCRIPTION
This moves some of the code that is platform dependent (e.g. getting various bits of system info) into a separate file that can be reused as needed between the different tippecanoe binaries, and should help keep conditional compilation #ifdef's for different operating systems in one place. This is laying the groundwork that will make support for new platforms (such as #293) cleaner/easier to maintain.