### PR TITLE
Add native AArch64 Linux CI test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         version: ['Release', 'Debug']
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub has made arm64 hosted-runners available free to public/open source repositories: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Here are the results from running the CI tests with the change to the build matrix: https://github.com/nightlark/tippecanoe/actions/runs/12837461438

Unfortunately they haven't added anything like a `ubuntu-latest-arm` label, but there have been a number of people commenting on their various announcement posts asking for one... so we'll see if they change their stance.