### PR TITLE
Reduce memory consumption during tiling and tile encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.75.1
+
+* Further reduce memory consumption in attribute sorting and tilestats tracking
+
 # 2.75.0
 
 * Reduce memory consumption in attribute accumulation and feature sorting

--- a/serial.hpp
+++ b/serial.hpp
@@ -165,7 +165,6 @@ struct serial_feature {
 	long long clustered;			       // does this feature need the clustered/point_count attributes?
 	const char *stringpool;			       // string pool for keys/values lookup
 	std::shared_ptr<std::string> tile_stringpool;  // string pool for mvt_value construction
-	std::set<std::string> need_tilestats;
 
 	int z;	// tile being produced
 	int tx;

--- a/tile.cpp
+++ b/tile.cpp
@@ -2574,6 +2574,9 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 					layer.tag(feature, *layer_features[x]->full_keys[a], v);
 				}
 
+				layer_features[x]->full_keys.clear();
+				layer_features[x]->full_values.clear();
+
 				if (additional[A_CALCULATE_FEATURE_DENSITY]) {
 					int glow = 255;
 					if (layer_features[x]->spacing > 0) {

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #ifndef VERSION_HPP
 #define VERSION_HPP
 
-#define VERSION "v2.75.0"
+#define VERSION "v2.75.1"
 
 #endif


### PR DESCRIPTION
This PR makes two further improvements to memory consumption:

1. When sorting the attribute values that are going into the `mvt_layer` to ensure their uniqueness, sort pointers to strings instead of the strings themselves. Clear the values from the vector as they are added to the PBF representation of the tile.
2. Remove the `need_tilestats` set of string attribute keys, since all attribute values that are added or changed in memory in the course of tile creation need to be reflected in tilestats anyway.