### PR TITLE
docs: fix typo in readme re: gamma

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ the same layer, enclose them in an `all` expression so they will all be evaluate
 
 ### Dropping tightly overlapping features
 
- * `-g` _gamma_ or `--gamma=_gamma`_: Rate at which especially dense dots are dropped (default 0, for no effect). A gamma of 2 reduces the number of dots less than a pixel apart to the square root of their original number.
+ * `-g` _gamma_ or `--gamma=`_gamma_: Rate at which especially dense dots are dropped (default 0, for no effect). A gamma of 2 reduces the number of dots less than a pixel apart to the square root of their original number.
  * `-aG` or `--increase-gamma-as-needed`: If a tile is too large, try to reduce it to under 500K by increasing the `-g` gamma. The discovered gamma applies to the entire zoom level. You probably want to use `--drop-densest-as-needed` instead.
 
 ### Line and polygon simplification


### PR DESCRIPTION
This fixes a very minor style issue in the note about how `--gamma` works.