### PR TITLE
Option to not averaging clusters of points

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3097,6 +3097,7 @@ int main(int argc, char **argv) {
 		{"coalesce-smallest-as-needed", no_argument, &additional[A_COALESCE_SMALLEST_AS_NEEDED], 1},
 		{"force-feature-limit", no_argument, &prevent[P_DYNAMIC_DROP], 1},
 		{"cluster-densest-as-needed", no_argument, &additional[A_CLUSTER_DENSEST_AS_NEEDED], 1},
+		{"keep-point-cluster-position", no_argument, &additional[A_KEEP_POINT_CLUSTER_POSITION], 1},
 
 		{"Dropping tightly overlapping features", 0, 0, 0},
 		{"gamma", required_argument, 0, 'g'},

--- a/options.hpp
+++ b/options.hpp
@@ -28,6 +28,7 @@
 #define A_VARIABLE_DEPTH_PYRAMID ((int) 't')
 #define A_VISVALINGAM ((int) 'v')
 #define A_DETECT_WRAPAROUND ((int) 'w')
+#define A_KEEP_POINT_CLUSTER_POSITION ((int) 'a')
 
 #define P_TILE_COMPRESSION ((int) 'C')
 #define P_DUPLICATION ((int) 'D')

--- a/tile.cpp
+++ b/tile.cpp
@@ -1948,7 +1948,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 					if ((sf.index < merge_previndex || sf.index - merge_previndex < cluster_mingap) && find_feature_to_accumulate_onto(features, sf, which_serial_feature, layer_unmaps, LLONG_MAX)) {
 						features[which_serial_feature]->clustered++;
 
-						if (features[which_serial_feature]->t == VT_POINT &&
+						if (!additional[A_KEEP_POINT_CLUSTER_POSITION] &&
+							features[which_serial_feature]->t == VT_POINT &&
 						    features[which_serial_feature]->geometry.size() == 1 &&
 						    sf.geometry.size() == 1) {
 							double x = (double) features[which_serial_feature]->geometry[0].x * features[which_serial_feature]->clustered;


### PR DESCRIPTION
It could be annoying when you zoom in and some features disappears. I've added a new option, when it's enabled  clusters will be represented by point with  real coordinates, not a mean of all points inside.