### PR TITLE
Add action to build and push docker to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge,branch=main
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -48,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tippecanoe
 Builds [vector tilesets](https://github.com/mapbox/vector-tile-spec/) from large (or small) collections of [GeoJSON](http://geojson.org/), [FlatGeobuf](https://github.com/flatgeobuf/flatgeobuf), or [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) features,
 [like these](MADE_WITH.md).
 
-This is the official home of Tippecanoe, developed and actively maintained by [Erica Fischer](https://github.com/e-n-f) at [Felt](https://felt.com). 
+This is the official home of Tippecanoe, developed and actively maintained by [Erica Fischer](https://github.com/e-n-f) at [Felt](https://felt.com).
 
 For a self-hosted, API driven version of Tippecanoe, contact a technical sales engineer at sales@felt.com. Felt produces highly performant, automatically projected versions of your data, and utilizes a rendering engine, built on top of [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js), to style vector and raster data.
 
@@ -39,6 +39,15 @@ The easiest way to install tippecanoe on OSX is with [Homebrew](http://brew.sh/)
 
 ```sh
 $ brew install tippecanoe
+```
+
+There is also a docker image that you can pull and run:
+
+```sh
+$ docker run -it --rm \
+  -v /tiledata:/data \
+  ghcr.io/felt/tippecanoe:latest \
+  tippecanoe --output=/data/output.mbtiles /data/example.geojson
 ```
 
 On Ubuntu it will usually be easiest to build from the source repository:


### PR DESCRIPTION
This adds a GitHub Action to build and publish to ghcr.io on push so users easily access a pre-built docker image.

```sh
$ docker run -it --rm \
  -v /tiledata:/data \
  ghcr.io/felt/tippecanoe:latest \
  tippecanoe --output=/data/output.mbtiles /data/example.geojson
```

It should automatically tag the releases, e.g.

* latest release: `ghcr.io/felt/tippecanoe:latest`
* major versions: `ghcr.io/felt/tippecanoe:2` 
* PRs: `ghcr.io/felt/tippecanoe:pr-348` 
* branches `ghcr.io/felt/tippecanoe:branchname`

Containers will also show up in the sidebar by releases. You can see what the first build looks like on my fork: https://github.com/bkeepers/tippecanoe/pkgs/container/tippecanoe