### PR TITLE
fix broken links in MADE_WITH.md

### DIFF
--- a/MADE_WITH.md
+++ b/MADE_WITH.md
@@ -1,19 +1,19 @@
-## [Visualizing a Month of Lightning](http://rousseau.io/2015/03/23/visualizing-a-month-of-lightning) by Jordan Rousseau
+## [Visualizing a Month of Lightning](https://medium.com/@jvrousseau/visualizing-a-month-of-lightning-8ab63d040d8c) by Jordan Rousseau
 
 ![](http://rousseau.io/assets/img/ltg-studio-style.png)
 
-## [Making the most detailed tweet map ever](https://www.mapbox.com/blog/twitter-map-every-tweet/) by Eric Fischer
+## [Making the most detailed tweet map ever](https://web.archive.org/web/20161220144946/https://www.mapbox.com/blog/twitter-map-every-tweet/) by Eric Fischer
 
 ![](https://farm8.staticflickr.com/7505/15869589271_8a02e84c24_b.jpg)
 
-## [Superpowering Runkeeper's 1.5 million walks, runs, and bike rides](https://www.mapbox.com/blog/runkeeper-million-routes/)
+## [Superpowering Runkeeper's 1.5 million walks, runs, and bike rides](https://web.archive.org/web/20161219225305/https://www.mapbox.com/blog/runkeeper-million-routes/)
 
 ![](https://c1.staticflickr.com/9/8605/15852245980_1ecf0894b8_b.jpg)
 
-## [The Geotaggers' World Atlas](https://www.mapbox.com/blog/geotaggers-world-atlas/) by Eric Fischer
+## [The Geotaggers' World Atlas](https://web.archive.org/web/20170319084321/https://www.mapbox.com/blog/geotaggers-world-atlas/) by Eric Fischer
 
 ![](http://farm8.staticflickr.com/7634/17040546408_0a14752e6d_b.jpg)
 
-## [Atmospheric River](https://www.mapbox.com/blog/atmospheric-river/)
+## [Atmospheric River](https://web.archive.org/web/20161011171030/https://www.mapbox.com/blog/atmospheric-river/)
 
 ![](http://farm9.staticflickr.com/8630/16253097589_4dfc706b22_b.jpg)


### PR DESCRIPTION
This updates the broken links in the [MADE_WITH.md](https://github.com/felt/tippecanoe/blob/main/MADE_WITH.md) file to point to Internet Archive versions of the original content.