### PR TITLE
Fix incorrect file reference in lambda README

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -6,7 +6,7 @@
     sudo yum install git clang sqlite-devel zlib-devel
 
 2. Create a ZIP archive with the `tippecanoe` binary at `bin/tippecanoe` and upload as a Lambda layer
-3. Copy [lambda_function.py](lambda_function.py) (python 3.9 runtime)
+3. Copy [tippecanoe.py](tippecanoe.py) (python 3.9 runtime)
 4. set the environment variable `OUTPUT_BUCKET` to your output bucket; give lambda IAM role access to input/output buckets
 5. Enable ACLs on the output bucket
 


### PR DESCRIPTION
This updates lambda/README.md to reference tippecanoe.py instead of the non-existent lambda_function.py. This prevents confusion for users following the Lambda setup instructions.