### PR TITLE
Upgrade docker base ubuntu version to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS tippecanoe-builder
+FROM ubuntu:24.04 AS tippecanoe-builder
 
 RUN apt-get update \
   && apt-get -y install make gcc g++ libsqlite3-dev zlib1g-dev
@@ -11,7 +11,7 @@ RUN make
 CMD make test
 
 # Using multistage build reduces the docker image size by alot by only copying the needed binaries
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update \
   && apt-get -y install libsqlite3-0 \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
CI supports `ubuntu-latest` (= `ubuntu-24.04` ([link](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images))) and `ubuntu-24.04-arm` since this January,
I upgraded docker base ubuntu version to 24.04.
https://github.com/felt/tippecanoe/blob/main/.github/workflows/test.yml#L10
```yml
        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
```