### PR TITLE
Fix: Respect -t temporary directory option in sorting operations

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2018,7 +2018,7 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 			vertex_readers.push_back(readers[i].vertexfile);
 			rewind(readers[i].vertexfile);
 		}
-		fqsort(vertex_readers, sizeof(vertex), vertexcmp, vertex_out, memsize / 20);
+		fqsort(vertex_readers, sizeof(vertex), vertexcmp, vertex_out, memsize / 20, tmpdir);
 
 		for (size_t i = 0; i < CPUS; i++) {
 			if (fclose(readers[i].vertexfile) != 0) {
@@ -2087,7 +2087,7 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 			rewind(readers[i].nodefile);
 		}
 
-		fqsort(node_readers, sizeof(node), nodecmp, node_out, memsize / 20);
+		fqsort(node_readers, sizeof(node), nodecmp, node_out, memsize / 20, tmpdir);
 
 		for (size_t i = 0; i < CPUS; i++) {
 			if (fclose(readers[i].nodefile) != 0) {

--- a/sort.cpp
+++ b/sort.cpp
@@ -6,7 +6,7 @@
 
 #define MAX_MEMORY (1024 * 1024 * 1024)	 // 1 GB
 
-void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, const void *), FILE *out, size_t mem) {
+void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, const void *), FILE *out, size_t mem, const char *tmpdir) {
 	std::string pivot;
 	FILE *fp1, *fp2;
 
@@ -67,8 +67,8 @@ void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, 
 		size_t pivot_off = width * (buf.size() / width / 2);
 		pivot = std::string(buf, pivot_off, width);
 
-		std::string t1 = "/tmp/sort1.XXXXXX";
-		std::string t2 = "/tmp/sort2.XXXXXX";
+		std::string t1 = std::string(tmpdir) + "/sort1.XXXXXX";
+		std::string t2 = std::string(tmpdir) + "/sort2.XXXXXX";
 
 		int fd1 = mkstemp((char *) t1.c_str());
 		unlink(t1.c_str());
@@ -117,11 +117,11 @@ void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, 
 
 	std::vector<FILE *> v1;
 	v1.emplace_back(fp1);
-	fqsort(v1, width, cmp, out, mem);
+	fqsort(v1, width, cmp, out, mem, tmpdir);
 	fclose(fp1);
 
 	std::vector<FILE *> v2;
 	v2.emplace_back(fp2);
-	fqsort(v2, width, cmp, out, mem);
+	fqsort(v2, width, cmp, out, mem, tmpdir);
 	fclose(fp2);
 }

--- a/sort.hpp
+++ b/sort.hpp
@@ -1,6 +1,6 @@
 #ifndef SORT_HPP
 #define SORT_HPP
 
-void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, const void *), FILE *out, size_t mem);
+void fqsort(std::vector<FILE *> &inputs, size_t width, int (*cmp)(const void *, const void *), FILE *out, size_t mem, const char *tmpdir);
 
 #endif

--- a/unit.cpp
+++ b/unit.cpp
@@ -73,7 +73,7 @@ TEST_CASE("External quicksort", "fqsort") {
 	unlink(tmpname.c_str());
 	FILE *f = fdopen(fd, "w+b");
 
-	fqsort(inputs, sizeof(int), intcmp, f, 256);
+	fqsort(inputs, sizeof(int), intcmp, f, 256, "/tmp");
 	rewind(f);
 
 	int prev = INT_MIN;


### PR DESCRIPTION
### Summary
This PR fixes a critical bug where the `-t` (temporary directory) command-line option was not being respected by sorting operations, causing temporary files to be created in hardcoded `/tmp` instead of the user-specified directory. This caused disk space issues when processing large files on systems with limited root filesystem space.

### Problem
When processing large datasets (e.g., 500GB+ FlatGeobuf files), tippecanoe would fill up the root `/` volume even when users explicitly specified an alternative temporary directory using `-t /path/to/large/volume`. This occurred because the `fqsort()` function in `sort.cpp` used hardcoded `/tmp` paths that ignored the `-t` parameter.

**Example failing scenario:**
```bash
# This would still create temp files in /tmp, filling up root volume
tippecanoe -t /data -o /data/output.mbtiles large_input.fgb
```

### Root Cause
The `fqsort()` function had hardcoded temporary file paths:
```cpp
std::string t1 = "/tmp/sort1.XXXXXX";
std::string t2 = "/tmp/sort2.XXXXXX";
```

These paths were used during:
- Vertex sorting operations (`main.cpp:2021`)
- Node sorting operations (`main.cpp:2090`)
- Large-scale data reorganization

### Solution
Modified the `fqsort()` function to accept a `tmpdir` parameter and use it for all temporary file creation:

1. **Updated function signature** (`sort.hpp`):
   - Added `const char *tmpdir` parameter

2. **Fixed implementation** (`sort.cpp`):
   - Replaced hardcoded `/tmp` paths with `std::string(tmpdir) + "/sort*.XXXXXX"`
   - Updated recursive calls to pass `tmpdir` parameter

3. **Updated call sites** (`main.cpp`):
   - Modified vertex and node sorting calls to pass `tmpdir`

4. **Updated tests** (`unit.cpp`):
   - Test now explicitly passes `/tmp` to maintain test behavior

### Changes Made
- `sort.hpp`: Updated `fqsort()` function signature
- `sort.cpp`: Fixed hardcoded paths and recursive calls (4 changes)
- `main.cpp`: Updated 2 `fqsort()` calls to pass `tmpdir`
- `unit.cpp`: Updated test call to pass `/tmp`

### Impact
✅ **Fixes critical issue**: Users can now process large files without filling up root filesystem  
✅ **Maintains backward compatibility**: All existing functionality preserved  
✅ **Consistent behavior**: All temporary files now respect the `-t` option  
✅ **Prevents data loss**: Eliminates risk of filling root filesystem and causing system instability

### Testing
- [x] Code compiles without warnings
- [x] Existing unit tests pass
- [x] Manual testing with large files confirms temp files created in specified directory
- [ ] Recommended: Test with multi-TB datasets on systems with limited root storage

### Breaking Changes
None. This is a backward-compatible bug fix.

### Related Issues
Fixes: [Issue #367](https://github.com/felt/tippecanoe/issues/367)

### Checklist
- [x] Code follows existing patterns in the codebase
- [x] Changes are minimal and focused on the specific issue
- [x] Function signatures updated consistently across all files
- [x] No new dependencies introduced
- [x] Maintains thread safety (uses same patterns as existing code)

---

**Note for reviewers:** This fix ensures that the `-t` option consistently controls ALL temporary file locations throughout the processing pipeline, not just some operations. This is critical for users processing large datasets on systems with constrained root storage, which is a common configuration for data processing servers.