### PR TITLE
minor manual page fix

### DIFF
--- a/man/tippecanoe.1
+++ b/man/tippecanoe.1
@@ -481,16 +481,16 @@ zoom level	precision (ft)	precision (m)	map scale
 .SS Tile resolution
 .RS
 .IP \(bu 2
-\fB\fC\-d\fR \fIdetail\fP or \fB\fC\-\-full\-detail=\fR\fIdetail\fP: Detail at max zoom level (default 12, for tile resolution of 2
+\fB\fC\-d\fR \fIdetail\fP or \fB\fC\-\-full\-detail=\fR\fIdetail\fP: Detail at max zoom level (default 12, for tile resolution of 2\(ha12=4096)
 .IP \(bu 2
-\fB\fC\-D\fR \fIdetail\fP or \fB\fC\-\-low\-detail=\fR\fIdetail\fP: Detail at lower zoom levels (default 12, for tile resolution of 2
+\fB\fC\-D\fR \fIdetail\fP or \fB\fC\-\-low\-detail=\fR\fIdetail\fP: Detail at lower zoom levels (default 12, for tile resolution of 2\(ha12=4096)
 .IP \(bu 2
 \fB\fC\-m\fR \fIdetail\fP or \fB\fC\-\-minimum\-detail=\fR\fIdetail\fP: Minimum detail that it will try if tiles are too big at regular detail (default 7)
 .IP \(bu 2
 \fB\fC\-\-extra\-detail=\fR\fIdetail\fP: Generate tiles with even more detail than the "full" detail at the max zoom level, to maximize location precision. These tiles may not work with some rendering software that internally limits detail to 12 or 13. The extra detail does not affect the choice of maxzoom guessing, the amount of simplification, or the "tiny polygon" threshold as \fB\fC\-\-full\-detail\fR does. The tiles should look the same as they did without it, except that they will be more precise when overzoomed.
 .RE
 .PP
-All internal math is done in terms of a 32\-bit tile coordinate system, so 1/(2 of the size of Earth,
+All internal math is done in terms of a 32\-bit tile coordinate system, so 1/(2\(ha32) of the size of Earth,
 or about 1cm, is the smallest distinguishable distance. If \fImaxzoom\fP + \fIdetail\fP > 32, no additional
 resolution is obtained than by using a smaller \fImaxzoom\fP or \fIdetail\fP, and the \fIdetail\fP of tiles will
 be reduced to the maximum that can be used with the specified \fImaxzoom\fP\&.


### PR DESCRIPTION
Looks like the conversion didn't handle the caret character well.

Should now match the relevant part of the markdown.