### PR TITLE
Add a JSON field called features_written

### DIFF
--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -444,6 +444,14 @@ std::string stringify_strategies(std::vector<strategy> const &strategies) {
 			any = true;
 		}
 
+		if (strategies[i].features_written > 0) {
+			state.nospace = true;
+			state.json_write_string("features_written");
+			state.nospace = true;
+			state.json_write_number(strategies[i].features_written);
+			any = true;
+		}
+
 		if (strategies[i].truncated_zooms > 0) {
 			state.nospace = true;
 			state.json_write_string("truncated_zooms");

--- a/tile.cpp
+++ b/tile.cpp
@@ -2588,6 +2588,14 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				}
 
 				layer.features.push_back(std::move(feature));
+
+				// Record the unique sequence number of this feature
+				long long feature_seq = layer_features[x]->seq;
+				{
+					std::lock_guard<std::mutex> lock(strategy_out->unique_features_mutex);
+					strategy_out->unique_feature_seqs.insert(feature_seq);
+				}
+
 				layer_features[x] = std::make_shared<serial_feature>();
 			}
 

--- a/tile.hpp
+++ b/tile.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <atomic>
 #include <map>
+#include <unordered_set>
+#include <mutex>
 #include "mbtiles.hpp"
 #include "serial.hpp"
 #include "attribute.hpp"
@@ -19,6 +21,10 @@ struct atomic_strategy {
 	std::atomic<size_t> detail_reduced;
 	std::atomic<size_t> tiny_polygons;
 	std::atomic<size_t> truncated_zooms;
+
+	// Track unique features written per zoom level
+	std::unordered_set<long long> unique_feature_seqs;
+	std::mutex unique_features_mutex;
 
 	atomic_strategy()
 	    : dropped_by_rate(0),
@@ -44,6 +50,7 @@ struct strategy {
 
 	size_t tile_size = 0;
 	size_t feature_count = 0;
+	size_t features_written = 0;
 
 	strategy(const atomic_strategy &s, size_t ts, size_t fc) {
 		dropped_by_rate = s.dropped_by_rate;
@@ -55,6 +62,7 @@ struct strategy {
 		feature_count = fc;
 		tiny_polygons = s.tiny_polygons;
 		truncated_zooms = s.truncated_zooms;
+		features_written = s.unique_feature_seqs.size();
 	}
 
 	strategy() = default;


### PR DESCRIPTION
alongside existing fields tiny_polygons and dropped_as_needed that are populated per zoom level. The existing fields cannot be used to calculate how many features were actually retained, hence the need for a new field if we want this data.

TESTED=compared JSON output against a script that loads and counts features at all zoom levels. 