### PR TITLE
Add option to remove geometry in `tile-join`

### DIFF
--- a/mvt.cpp
+++ b/mvt.cpp
@@ -407,7 +407,8 @@ std::string mvt_tile::encode() {
 			std::string feature_string;
 			protozero::pbf_writer feature_writer(feature_string);
 
-			feature_writer.add_enum(3, layers[i].features[f].type);
+			if (layers[i].features[f].type >= 0) 
+				feature_writer.add_enum(3, layers[i].features[f].type);
 
 			std::vector<unsigned> sorted_tags = layers[i].features[f].tags;
 			for (size_t v = 1; v < sorted_tags.size(); v += 2) {


### PR DESCRIPTION
As discussed in #381, this PR adds an option to `tile-join` to remove geometries from all features while preserving feature IDs and attributes.

The option uses the flag `--exclude-all-tile-geometries`, following the naming style of the existing undocumented `--exclude-all-tile-attributes` flag.

When enabled, the geometry field is omitted from each feature. The feature.type field is also omitted, since it would no longer be meaningful without geometry, and retaining it would unnecessarily affect layer statistics and slightly increase tile size.

This option is explicitly opt-in and intended for advanced workflows where geometry is provided separately and [merged client-side](https://github.com/indus/maplibre-merge-protocol).

