### PR TITLE
Keep features at the attribute threshold instead of dropping them (384 follow up)

### DIFF
--- a/tile.cpp
+++ b/tile.cpp
@@ -833,12 +833,9 @@ static double choose_minattribute(std::vector<double> &attribute_values, double 
 	std::stable_sort(attribute_values.begin(), attribute_values.end());
 
 	if (descending) {
-		// For descending: threshold moves down, drop features >= threshold
-		// Use ceil so ix points at the first value to drop, not the last to keep
-		size_t ix = (size_t)ceil((double)(attribute_values.size() - 1) * f);
-		if (ix >= attribute_values.size()) {
-			ix = attribute_values.size() - 1;
-		}
+		// For descending: drop features > threshold, keep features <= threshold
+		// ix points at the last value to keep
+		size_t ix = (size_t)((attribute_values.size() - 1) * f);
 		while (ix > 0 && attribute_values[ix] >= existing_attribute) {
 			ix--;
 		}
@@ -849,8 +846,12 @@ static double choose_minattribute(std::vector<double> &attribute_values, double 
 
 		return attribute_values[ix];
 	} else {
-		// For ascending: threshold moves up, drop features <= threshold
-		size_t ix = (attribute_values.size() - 1) * (1 - f);
+		// For ascending: drop features < threshold, keep features >= threshold
+		// ix points at the first value to keep
+		size_t ix = (size_t)ceil((double)(attribute_values.size() - 1) * (1 - f));
+		if (ix >= attribute_values.size()) {
+			ix = attribute_values.size() - 1;
+		}
 		while (ix + 1 < attribute_values.size() && attribute_values[ix] <= existing_attribute) {
 			ix++;
 		}
@@ -2109,8 +2110,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 					if (attr_valid) {
 						add_sample_to(attribute_values, attr_numeric, attribute_values_increment, seq);
 						bool should_drop = arg->drop_by_attribute_descending
-							? (minattribute != HUGE_VAL && attr_numeric >= minattribute)
-							: (minattribute != -HUGE_VAL && attr_numeric <= minattribute);
+							? (minattribute != HUGE_VAL && attr_numeric > minattribute)
+							: (minattribute != -HUGE_VAL && attr_numeric < minattribute);
 						if (should_drop) {
 							can_stop_early = false;
 							if (drop_feature_unless_it_can_be_added_to_a_multiplier_cluster(layer, sf, layer_unmaps, strategy, drop_rest, arg->attribute_accum, key_pool)) {
@@ -2801,7 +2802,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 							fprintf(stderr,
 								"Trying to keep features with '%s' %s %.6f to make it fit\n",
 								arg->drop_by_attribute_as_needed_attribute->c_str(),
-								desc ? "<" : ">",
+								desc ? "<=" : ">=",
 								minattribute);
 						}
 						line_detail++;
@@ -2970,7 +2971,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 							arg->still_dropping = true;
 						}
 						if (!quiet) {
-							fprintf(stderr, "Going to try keeping features with attribute '%s' %s %0.6f to make it fit\n", arg->drop_by_attribute_as_needed_attribute->c_str(), desc2 ? "<" : ">", minattribute);
+							fprintf(stderr, "Going to try keeping features with attribute '%s' %s %0.6f to make it fit\n", arg->drop_by_attribute_as_needed_attribute->c_str(), desc2 ? "<=" : ">=", minattribute);
 						}
 						line_detail++;
 						continue;


### PR DESCRIPTION
Quick follow on to #384 (sorry!). Realized that it might be better to keep values that match the threshold instead of dropping them. This avoids over-dropping when many features share the same attribute value. 

No change to the golden test output from this change. 