### PR TITLE
Keep variable-depth pyramids from pruning features above their minzoom

### DIFF
--- a/tile.cpp
+++ b/tile.cpp
@@ -1097,6 +1097,9 @@ static bool skip_next_feature(decompressor *geoms, std::atomic<long long> *geomp
 struct next_feature_state {
 	unsigned long long previndex = 0;
 	unsigned long long prev_not_dropped_index = 0;
+	// set when a feature excluded by tippecanoe_minzoom first appears beyond the next
+	// zoom, so variable-depth pyramids don't leaf above the feature's minzoom and prune it away
+	bool minzoom_feature_pending = false;
 };
 
 // This function is called repeatedly from write_tile() to retrieve the next feature
@@ -1202,6 +1205,9 @@ static serial_feature next_feature(decompressor *geoms, std::atomic<long long> *
 		}
 
 		if (sf.tippecanoe_minzoom != -1 && z < sf.tippecanoe_minzoom) {
+			if (sf.tippecanoe_minzoom > z + 1) {
+				next_feature_state.minzoom_feature_pending = true;
+			}
 			continue;
 		}
 		if (sf.tippecanoe_maxzoom != -1 && z > sf.tippecanoe_maxzoom) {
@@ -2315,7 +2321,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			if (within[j]) {
 				long long estimated_complexity_out = geompos[j] - start_geompos[j];
 
-				if (dropping_by_rate) {
+				if (dropping_by_rate || next_feature_state.minzoom_feature_pending) {
 					// large enough to make it not try to stop early
 					estimated_complexity_out = 1LL << 32;
 				}


### PR DESCRIPTION
### Problem

Under `--generate-variable-depth-tile-pyramid`, a feature with an explicit per-feature `tippecanoe.minzoom` set deeper than the zoom at which its area leafs is silently dropped from the archive. It renders at no zoom, baked or overzoomed.

### Reproduction

21 line features in a small area: one with `tippecanoe.minzoom = 2`, twenty with `tippecanoe.minzoom = 12`. Because all 21 fit at full detail in a shallow tile, the pyramid leafs early:

```
tippecanoe -f -o out.mbtiles --generate-variable-depth-tile-pyramid -z14 -Z0 -l lines lines.geojsonseq
```

| build | zoom levels in archive | minzoom-12 lines present |
|-------|------------------------|--------------------------|
| master `0c650b8` | `[2]` | 0 / 20 |
| with this change | `[2..12]` | 20 / 20 |

Master leafs at z2 and prunes z3+, so the twenty features (which only appear at z >= 12) never exist anywhere. With the change the pyramid subdivides down to z12, leafs there, and all twenty are present. Variable depth still stops as early as the data allows; it just no longer stops above content that is still due to appear.

### Root cause

In `tile.cpp`:

1. `next_feature()` propagates each feature to the next zoom's child shards (`rewrite(...)`, gated only by `tippecanoe_maxzoom`) before the minzoom test, so the data is present in every child stream.
2. It then excludes the feature from the current tile and `continue`s (`z < sf.tippecanoe_minzoom`), so the feature never returns to `write_tile()`'s main loop.
3. The variable-depth leaf decision and its guard live in that main loop. The guard that keeps a tile subdividing while deeper features are pending checks only `sf.feature_minzoom` (the dot-dropping minzoom), which is a distinct field from `sf.tippecanoe_minzoom` and is never assigned from it.

So an explicit-minzoom feature is both invisible to the guard (excluded inside `next_feature`) and absent from the leaf (`z < minzoom`), while its subtree is pruned.

### Fix

Carry a flag out of `next_feature()` when an excluded feature first appears beyond the next zoom, and OR it into the existing `estimated_complexity_out` leaf-prevention path, mirroring what `feature_minzoom` already does. Three small edits, all in `tile.cpp`:

- add `bool minzoom_feature_pending` to `next_feature_state`;
- set it at the `tippecanoe_minzoom` exclusion when `tippecanoe_minzoom > z + 1`;
- `if (dropping_by_rate || next_feature_state.minzoom_feature_pending)` at the child-complexity write.

### Testing

- New before/after reproduction above (line features; the same holds for points and polygons).
- `make test` passes: 10,465 assertions, no fixture diffs. `estimated_complexity_out` is only written under `--generate-variable-depth-tile-pyramid`, so output without that flag is unchanged, which is why no existing fixture moves.

### Scope note

`tippecanoe_maxzoom` is unaffected: a feature past its maxzoom is correctly absent deeper, and a leaf below its maxzoom still carries it. This defect is minzoom-only.
