### PR TITLE
Variable-depth pyramids: don't prune children while a minzoom-gated feature is still pending

### DIFF
--- a/tests/minzoom-variable-depth/in.json
+++ b/tests/minzoom-variable-depth/in.json
@@ -1,0 +1,2 @@
+{"type":"Feature","id":1,"tippecanoe":{"minzoom":10},"properties":{"depth":10},"geometry":{"type":"Point","coordinates":[0.05,0.05]}}
+{"type":"Feature","id":2,"tippecanoe":{"minzoom":11},"properties":{"depth":11},"geometry":{"type":"Point","coordinates":[0.06,0.06]}}

--- a/tests/minzoom-variable-depth/out/-Z10_-z11_--generate-variable-depth-tile-pyramid.json
+++ b/tests/minzoom-variable-depth/out/-Z10_-z11_--generate-variable-depth-tile-pyramid.json
@@ -1,0 +1,28 @@
+{ "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "0.050000,0.050000,0.060000,0.060000",
+"bounds": "0.050000,0.050000,0.060000,0.060000",
+"center": "0.060000,0.060000,11",
+"description": "tests/minzoom-variable-depth/out/-Z10_-z11_--generate-variable-depth-tile-pyramid.json.check.mbtiles",
+"format": "pbf",
+"generator_options": "./tippecanoe -q -a@ -f -o tests/minzoom-variable-depth/out/-Z10_-z11_--generate-variable-depth-tile-pyramid.json.check.mbtiles -Z10 -z11 --generate-variable-depth-tile-pyramid tests/minzoom-variable-depth/in.json",
+"json": "{\"vector_layers\":[{\"id\":\"in\",\"description\":\"\",\"minzoom\":10,\"maxzoom\":11,\"fields\":{\"depth\":\"Number\"}}],\"tilestats\":{\"layerCount\":1,\"layers\":[{\"layer\":\"in\",\"count\":2,\"geometry\":\"Point\",\"attributeCount\":1,\"attributes\":[{\"attribute\":\"depth\",\"count\":2,\"type\":\"number\",\"values\":[10,11],\"min\":10,\"max\":11}]}]}}",
+"maxzoom": "11",
+"minzoom": "10",
+"name": "tests/minzoom-variable-depth/out/-Z10_-z11_--generate-variable-depth-tile-pyramid.json.check.mbtiles",
+"type": "overlay",
+"version": "2"
+}, "features": [
+{ "type": "FeatureCollection", "properties": { "zoom": 10, "x": 512, "y": 511 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "in", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 1, "properties": { "depth": 10 }, "geometry": { "type": "Point", "coordinates": [ 0.050039, 0.049953 ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 11, "x": 1024, "y": 1023 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "in", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 1, "properties": { "depth": 10 }, "geometry": { "type": "Point", "coordinates": [ 0.049996, 0.049996 ] } }
+,
+{ "type": "Feature", "id": 2, "properties": { "depth": 11 }, "geometry": { "type": "Point", "coordinates": [ 0.059996, 0.059996 ] } }
+] }
+] }
+] }

--- a/tile.cpp
+++ b/tile.cpp
@@ -1205,9 +1205,9 @@ static serial_feature next_feature(decompressor *geoms, std::atomic<long long> *
 		}
 
 		if (sf.tippecanoe_minzoom != -1 && z < sf.tippecanoe_minzoom) {
-			if (sf.tippecanoe_minzoom > z + 1) {
-				next_feature_state.minzoom_feature_pending = true;
-			}
+			// a leaf at z carries only z-visible content, so an excluded feature at
+			// any deeper minzoom (even z + 1) must block leafing here
+			next_feature_state.minzoom_feature_pending = true;
 			continue;
 		}
 		if (sf.tippecanoe_maxzoom != -1 && z > sf.tippecanoe_maxzoom) {
@@ -2684,7 +2684,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			oprogress = progress;
 		}
 
-		if (trying_to_stop_early && line_detail == first_detail && !can_stop_early) {
+		if (trying_to_stop_early && line_detail == first_detail && (!can_stop_early || next_feature_state.minzoom_feature_pending)) {
 			// didn't work, try a lower detail
 			continue;
 		}
@@ -3036,9 +3036,10 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 					exit(EXIT_PTHREAD);
 				}
 
-				if (trying_to_stop_early && line_detail == first_detail) {
-					// We succeeded in stopping early.
-					// Prune the child tiles.
+				if (trying_to_stop_early && line_detail == first_detail &&
+				    !next_feature_state.minzoom_feature_pending) {
+					// We succeeded in stopping early (and no excluded feature is
+					// waiting for a deeper zoom). Prune the child tiles.
 
 					strategy.truncated_zooms++;
 					skip_children_out.insert(zxy(z, tx, ty));


### PR DESCRIPTION
Follow-up to #397. That fix added a `minzoom_feature_pending` flag so variable-depth pyramids keep subdividing until per-feature `tippecanoe.minzoom` gates are satisfied, but two gaps remained, and together they still drop features:

1. The flag is only set when `tippecanoe_minzoom > z + 1`. A feature with minzoom exactly `z + 1` never marks the tile pending, even though a leaf at `z` carries only z-visible content and that feature still needs `z + 1` to exist.
2. The early-stop commit path never consults the flag. When a tile succeeds at stopping early (`trying_to_stop_early && line_detail == first_detail`), it inserts itself into `skip_children_out` unconditionally, pruning the children the pending feature needed. The flag only inflated the estimated complexity stamped into the child geometry stream, and the pruning ignores that stamp.

So a feature whose minzoom is deeper than the zoom where its region's pyramid stops still lands in no tile at all. Reproduction with two points:

```
{"type":"Feature","id":1,"tippecanoe":{"minzoom":10},"geometry":{"type":"Point","coordinates":[0.05,0.05]}}
{"type":"Feature","id":2,"tippecanoe":{"minzoom":11},"geometry":{"type":"Point","coordinates":[0.06,0.06]}}
```

```
tippecanoe -o out.pmtiles -f --generate-variable-depth-tile-pyramid -Z10 -z11 -P in.geojsons
```

Before this change, `tippecanoe-decode` shows only feature 1 in a z10 leaf; feature 2 is gone. After, the z10 tile keeps its children and feature 2 appears at z11.

I hit this in production on https://github.com/openwatersio/seascape/pull/83: a planet run silently dropped features whose minzoom sat one zoom below where the surrounding ocean leafed. An id-completeness check comparing input features against decoded tiles caught it; nothing in tippecanoe's output indicated a problem.

The change is three small edits in tile.cpp: set the pending flag for any feature excluded below its minzoom, include the flag in the early-stop veto, and skip child pruning while it is set. The existing #397 test still passes; a new test covers the minzoom == z + 1 boundary.