### PR TITLE
docs: fix broken All Streets link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the density and texture of the data rather than a simplification from dropping
 supposedly unimportant features or clustering or aggregating them.
 
 If you give it all of OpenStreetMap and zoom out, it should give you back
-something that looks like "[All Streets](http://benfry.com/allstreets/map5.html)"
+something that looks like "[All Streets](https://benfry.com/allstreets/)"
 rather than something that looks like an Interstate road atlas.
 
 If you give it all the building footprints in Los Angeles and zoom out


### PR DESCRIPTION
## What

The `[All Streets]` reference in the README's "Intent" section links to `http://benfry.com/allstreets/map5.html`, which now returns **HTTP 404**. Point it at the live All Streets project page, `https://benfry.com/allstreets/` (HTTP 200).

## Verification

One line in `README.md`. Confirmed the old URL returns 404 and the replacement returns 200 and serves the "All Streets" project page.

Closes #398.

---

Disclosure: prepared with AI assistance; I reviewed the change and verified both URLs.
