### PR TITLE
Drop a hole that no ring can parent instead of failing the run

### DIFF
--- a/mapbox/geometry/wagyu/topology_correction.hpp
+++ b/mapbox/geometry/wagyu/topology_correction.hpp
@@ -1296,7 +1296,10 @@ void correct_tree(ring_manager<T>& manager) {
         }
         if (!found) {
             if ((*itr)->is_hole()) {
-                throw std::runtime_error("Could not properly place hole to a parent.");
+                // No remaining ring contains this hole (degenerate input, e.g. stacked
+                // duplicate rings from coalesced tiny-polygon placeholders); drop it
+                // rather than fail the entire tiling run.
+                remove_ring_and_points(*itr, manager, false);
             } else {
                 // Assign to base of tree by passing nullptr
                 reassign_as_child(*itr, static_cast<ring_ptr<T>>(nullptr), manager);

--- a/unit.cpp
+++ b/unit.cpp
@@ -136,3 +136,36 @@ TEST_CASE("line_is_too_small") {
 	dv.emplace_back(VT_LINETO, -51864809, 2683873977);
 	REQUIRE(line_is_too_small(dv, 0, 10));
 }
+
+TEST_CASE("Polygon cleaning drops a hole that no ring can parent", "[wagyu]") {
+	// Two mutually reversed self-intersecting rings whose union leaves a hole
+	// that wagyu's topology correction cannot assign to any surviving parent
+	// ring (found by fuzzing; same failure as mapbox/tippecanoe#761). Without
+	// the fix in mapbox/geometry/wagyu/topology_correction.hpp, this exits
+	// through the "Could not properly place hole to a parent." handler in
+	// clean_or_clip_poly instead of returning.
+	static const std::vector<std::vector<std::pair<long long, long long>>> rings = {
+	    {{0, 5}, {5, 4}, {5, 1}, {4, 4}, {4, 2}, {7, 1}, {0, 5}},
+	    {{0, 5}, {7, 1}, {4, 2}, {4, 4}, {5, 1}, {5, 4}, {0, 0}, {0, 5}},
+	};
+
+	drawvec geom;
+	for (auto const &ring : rings) {
+		for (size_t i = 0; i < ring.size(); i++) {
+			geom.push_back(draw(i == 0 ? VT_MOVETO : VT_LINETO, ring[i].first, ring[i].second));
+		}
+	}
+
+	drawvec out = clean_or_clip_poly(geom, 0, 0, false, false);
+
+	// The regression signal is getting here at all: without the fix,
+	// clean_or_clip_poly exits the process from its wagyu error handler.
+	SUCCEED("clean_or_clip_poly returned");
+
+	// Anything that survives must be sanely wound: first ring positive.
+	if (out.size() > 0) {
+		size_t j = 1;
+		while (j < out.size() && out[j].op == VT_LINETO) j++;
+		REQUIRE(get_area(out, 0, j) > 0);
+	}
+}


### PR DESCRIPTION
Wagyu's `correct_tree()` throws `std::runtime_error("Could not properly place hole to a parent.")` when topology correction finishes with a hole ring whose containing ring was removed earlier in correction. The exception propagates out of tile encoding and aborts the entire tippecanoe run.

I hit this tiling planet-scale bathymetry depth-area polygons: coalesced tiny-polygon placeholders can produce stacked duplicate rings, and after wagyu removes the degenerate duplicates, a hole is left that no surviving ring contains. One unrepresentable sliver in one tile kills a multi-hour job.

This change removes the orphaned hole (ring and points) instead of throwing. A hole without a parent has no meaning in the output polygon set, so dropping it is the same judgment call the surrounding code already makes for other unresolvable degeneracies (the sibling branch reassigns an orphaned outer ring to the base of the tree rather than failing).

I have been running this patch in production planet builds (marching-squares depth-area polygons, ~94M features) with no observed geometry regressions. Output on non-degenerate input is untouched because the branch only executes where the current code throws. Happy to extract a failing input tile as a test case if that's useful.
