### PR TITLE
Keep the radix sort from recursing forever when it runs out of files

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -742,8 +742,16 @@ void start_parsing(int fd, STREAM *fp, long long offset, long long len, std::ato
 }
 
 void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int splits, long long mem, const char *tmpdir, long long *availfiles, FILE *geomfile, FILE *indexfile, std::atomic<long long> *geompos_out, long long *progress, long long *progress_max, long long *progress_reported, int maxzoom, int basezoom, double droprate, double gamma, struct drop_state *ds) {
-	// Arranged as bits to facilitate subdividing again if a subdivided file is still huge
-	int splitbits = log(splits) / log(2);
+	// Arranged as bits to facilitate subdividing again if a subdivided file is still huge.
+	//
+	// There must be at least two buckets: with only one, each subdivision would
+	// consume no bits of the index, so it would never reach the maximum prefix
+	// that stops the recursion, and the shift below would be by the full width
+	// of the index, which is undefined.
+	int splitbits = 1;
+	if (splits > 1) {
+		splitbits = log(splits) / log(2);
+	}
 	splits = 1 << splitbits;
 
 	FILE *geomfiles[splits];
@@ -890,7 +898,14 @@ void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int split
 		}
 
 		if (indexst.st_size > 0) {
-			if (indexst.st_size + geomst.st_size < mem) {
+			// Subdividing again would only make progress if the next level could
+			// split into at least two buckets, which it can't if there are no longer
+			// enough files left to do it with. In that case, sort in memory instead,
+			// even though this is more memory than we wanted to use at once, since
+			// it is the only way left to get this bucket sorted.
+			bool can_subdivide = *availfiles / 4 > 1;
+
+			if (indexst.st_size + geomst.st_size < mem || !can_subdivide) {
 				std::atomic<long long> indexpos(indexst.st_size);
 				int bytes = sizeof(struct index);
 


### PR DESCRIPTION
`--prefer-radix-sort` segfaults on `tests/feature-filter/in.json`:

```
$ ./tippecanoe -q -f -o out.mbtiles -z0 -aR tests/feature-filter/in.json
Segmentation fault
```

## What happens

`radix1()` subdivides a bucket by the next `splitbits` bits of the index and stops recursing once `prefix + splitbits` reaches the width of the index. The number of buckets is derived from the number of files still available, which shrinks at every level. Instrumenting the descent on that input:

```
radix1 prefix=0  splits=256 splitbits=8 availfiles=1482
radix1 prefix=8  splits=256 splitbits=8 availfiles=1126
...
radix1 prefix=59 splits=2   splitbits=1 availfiles=14
radix1 prefix=60 splits=2   splitbits=1 availfiles=12
radix1 prefix=61 splits=2   splitbits=1 availfiles=10
radix1 prefix=62 splits=2   splitbits=1 availfiles=8
radix1 prefix=63 splits=1   splitbits=0 availfiles=6     <-- fixed point
radix1 prefix=63 splits=1   splitbits=0 availfiles=6
radix1 prefix=63 splits=1   splitbits=0 availfiles=6
...
```

Once `availfiles / 4` reaches 1, `splitbits` is 0. The recursion then consumes no bits of the index, and the net change to `availfiles` per level is also 0, so `prefix` stays at 63 forever and the recursion has no way to terminate. It ran about 6900 levels deep before exhausting the stack.

There is a second problem at `splitbits == 0`. The bucket a feature belongs to is

```c
unsigned long long which = (ix.ix << prefix) >> (64 - splitbits);
```

which becomes a shift by 64, the full width of the value, and is undefined. In practice the shift count is masked to zero, so `which` comes out as the whole shifted index rather than 0, and `geomfiles[which]` / `indexfiles[which]` write far off the end of the arrays of open files. On this input the surviving indices happen to be even, so `ix.ix << 63` is 0 and it is the stack that runs out first, but an odd index there would corrupt memory instead.

## Fix

Require at least two buckets, so that every subdivision consumes at least one bit of the index and the shift is always in range. This also avoids `log(0)` when `splits` is 0.

Don't recurse at all when the next level would not have enough files left to split with. That bucket is sorted in memory instead, even though it is larger than the memory limit asked for, since that is the only way left to get it sorted — the limit is there to avoid thrashing, not for correctness, and the alternative is not finishing.

Normal runs are unaffected: `mem` is half of the available memory rather than the 8K that `--prefer-radix-sort` uses, so reaching a bucket that is both over the limit and out of files would take on the order of thirteen levels of recursion.

## Verification

The segfault is gone. `tests/feature-filter/in.json` now fails at exit 106 instead, on the unrelated geometry-stream desync in `radix1()`'s direct-write path that #402 fixes. The two are independent; with both changes applied, `-aR` succeeds on every input it currently fails on and produces output byte-identical to the ordinary in-memory sort:

| input | `-z4 -aR` vs `-z4` |
| --- | --- |
| `tests/feature-filter/in.json` | identical |
| `tests/ne_110m_ocean/in.json` | identical |
| `tests/border/in.json` | identical |
| `tests/epsg-3857/in.json` | identical |
| `tests/loop/in.json` | identical |
| `tests/tl_2022_11_tract/in.json.gz` | identical |

`make test` passes.

## No test here

A differential target that runs some inputs with and without `-aR` and compares the decoded output — the same shape as the existing `parallel-test` — is the natural regression test for this, and that comparison is exactly what the table above is. But it cannot go green until both this and #402 have landed, so it would only make CI red on whichever merges first. Happy to open it as a follow-up once both are in.

---
_Generated by [Claude Code](https://claude.ai/code/session_011wLk2itWETPBAS9a9yE8zu)_