### PR TITLE
Fix the radix sort, and check that it agrees with the in-memory sort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ indent:
 TESTS = $(wildcard tests/*/out/*.json)
 SPACE = $(NULL) $(NULL)
 
-test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test
+test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test radix-sort-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test
 	./unit
 
 suffixes = json json.gz
@@ -132,7 +132,7 @@ nogeobuf = tests/overflow/out/-z0.json $(wildcard tests/stringid/out/*.json)
 geobuf-test: tippecanoe-json-tool $(addsuffix .checkbuf,$(filter-out $(nogeobuf),$(TESTS)))
 
 # For quicker address sanitizer build, hope that regular JSON parsing is tested enough by parallel and join tests
-fewer-tests: tippecanoe tippecanoe-decode geobuf-test raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit
+fewer-tests: tippecanoe tippecanoe-decode geobuf-test raw-tiles-test parallel-test radix-sort-test pbf-test join-test enumerate-test decode-test join-filter-test unit
 
 # XXX Use proper makefile rules instead of a for loop
 %.json.checkbuf:
@@ -142,6 +142,41 @@ fewer-tests: tippecanoe tippecanoe-decode geobuf-test raw-tiles-test parallel-te
 	./tippecanoe-decode -x generator $@.mbtiles | sed 's/checkbuf/check/g' | sed 's/\.geobuf//g' > $@.out
 	cmp $@.out $(patsubst %.checkbuf,%,$@)
 	rm $@.out $@.mbtiles
+
+# The result of the sort must not depend on how the sort was performed, so instead of
+# checking the sorted output against an expected copy of it, check that sorting by radix
+# produces the same tiles as sorting in memory. --prefer-radix-sort lowers the memory
+# limit to 8K so that the radix subdivision has to recurse, and how deeply it recurses
+# then depends on how many files the machine will let us open at once, but the sorted
+# result is the same either way, so this comparison doesn't depend on that.
+#
+# What sends the sort down its rarely-taken paths is the shape of the input rather than
+# the size of it: a feature whose geometry alone is bigger than the memory limit is
+# sorted as a bucket of its own, and features that share a long run of leading index
+# bits have to be subdivided until there are no bits left. The first two inputs are
+# each one of those on purpose -- several separated features too big to sort in memory,
+# and many features at one location -- and the rest are for breadth.
+radix-sort-test: tippecanoe tippecanoe-decode
+	mkdir -p tests/radix-sort
+	perl -e 'for ($$f = 0; $$f < 8; $$f++) { print "{ \"type\": \"Feature\", \"properties\": { \"f\": $$f }, \"geometry\": { \"type\": \"LineString\", \"coordinates\": ["; for ($$i = 0; $$i < 2000; $$i++) { print "," unless $$i == 0; printf "[%f,%f]", $$f * 40 - 175 + $$i * 0.001, $$i % 2 * 0.5 - 20; } print "] } }\n"; }' > tests/radix-sort/bigfeatures.json
+	perl -e 'for ($$i = 0; $$i < 500; $$i++) { print "{ \"type\": \"Feature\", \"properties\": { \"i\": $$i }, \"geometry\": { \"type\": \"Point\", \"coordinates\": [ 17, 42 ] } }\n"; }' > tests/radix-sort/onelocation.json
+	$(MAKE) radix-sort-compare RADIXIN="tests/radix-sort/bigfeatures.json" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/radix-sort/onelocation.json" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/feature-filter/in.json" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/ne_110m_ocean/in.json" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/border/in.json" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/loop/in.json" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/tl_2022_11_tract/in.json.gz" RADIXARGS="-z4"
+	$(MAKE) radix-sort-compare RADIXIN="tests/epsg-3857/in.json" RADIXARGS="-z4 -sEPSG:3857"
+	rm -r tests/radix-sort
+
+radix-sort-compare:
+	./tippecanoe -q -f $(RADIXARGS) -o tests/radix-sort/memory.mbtiles $(RADIXIN)
+	./tippecanoe -q -f $(RADIXARGS) -aR -o tests/radix-sort/radix.mbtiles $(RADIXIN)
+	./tippecanoe-decode -x generator -x generator_options -x name -x description tests/radix-sort/memory.mbtiles > tests/radix-sort/memory.json
+	./tippecanoe-decode -x generator -x generator_options -x name -x description tests/radix-sort/radix.mbtiles > tests/radix-sort/radix.json
+	cmp tests/radix-sort/memory.json tests/radix-sort/radix.json
+	rm tests/radix-sort/memory.mbtiles tests/radix-sort/radix.mbtiles tests/radix-sort/memory.json tests/radix-sort/radix.json
 
 parallel-test: $(eval SHELL:=$(ADVSHELL))
 	mkdir -p tests/parallel

--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,10 @@ fewer-tests: tippecanoe tippecanoe-decode geobuf-test raw-tiles-test parallel-te
 # The result of the sort must not depend on how the sort was performed, so instead of
 # checking the sorted output against an expected copy of it, check that sorting by radix
 # produces the same tiles as sorting in memory. --prefer-radix-sort lowers the memory
-# limit to 8K so that the radix subdivision has to recurse, and how deeply it recurses
-# then depends on how many files the machine will let us open at once, but the sorted
-# result is the same either way, so this comparison doesn't depend on that.
+# limit to 8K, which radix() then halves again, so the radix subdivision has to recurse
+# until each bucket is under 4K. How deeply that recurses depends on how many files the
+# machine will let us open at once, but the sorted result is the same either way, so
+# this comparison doesn't depend on that.
 #
 # What sends the sort down its rarely-taken paths is the shape of the input rather than
 # the size of it: a feature whose geometry alone is bigger than the memory limit is

--- a/main.cpp
+++ b/main.cpp
@@ -993,7 +993,11 @@ void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int split
 					struct index ix = indexmap[a];
 					long long pos = *geompos_out;
 
-					fwrite_check(geommap + ix.start, ix.end - ix.start, 1, geomfile, geompos_out, "geom");
+					// MAGIC: This knows that the feature minzoom is the last byte of the serialized feature
+					// and is writing one byte less and then adding the byte for the minzoom,
+					// the same as merge() does.
+
+					fwrite_check(geommap + ix.start, 1, ix.end - ix.start - 1, geomfile, geompos_out, "geom");
 					int feature_minzoom = calc_feature_minzoom(&ix, ds, maxzoom, gamma);
 					serialize_byte(geomfile, feature_minzoom, geompos_out, "merge geometry");
 

--- a/main.cpp
+++ b/main.cpp
@@ -744,10 +744,14 @@ void start_parsing(int fd, STREAM *fp, long long offset, long long len, std::ato
 void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int splits, long long mem, const char *tmpdir, long long *availfiles, FILE *geomfile, FILE *indexfile, std::atomic<long long> *geompos_out, long long *progress, long long *progress_max, long long *progress_reported, int maxzoom, int basezoom, double droprate, double gamma, struct drop_state *ds) {
 	// Arranged as bits to facilitate subdividing again if a subdivided file is still huge.
 	//
-	// There must be at least two buckets: with only one, each subdivision would
+	// There must be at least two buckets. With only one, each subdivision would
 	// consume no bits of the index, so it would never reach the maximum prefix
-	// that stops the recursion, and the shift below would be by the full width
-	// of the index, which is undefined.
+	// that stops the recursion, and the shift that chooses a feature's bucket
+	// below would be by the full width of the index. That shift is undefined,
+	// and what it does in practice is to mask the shift count down to zero, so
+	// the bucket number comes out as the whole shifted index instead of as 0
+	// and the writes are made through whatever is found beyond the end of the
+	// arrays of buckets.
 	int splitbits = 1;
 	if (splits > 1) {
 		splitbits = log(splits) / log(2);

--- a/main.cpp
+++ b/main.cpp
@@ -742,8 +742,16 @@ void start_parsing(int fd, STREAM *fp, long long offset, long long len, std::ato
 }
 
 void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int splits, long long mem, const char *tmpdir, long long *availfiles, FILE *geomfile, FILE *indexfile, std::atomic<long long> *geompos_out, long long *progress, long long *progress_max, long long *progress_reported, int maxzoom, int basezoom, double droprate, double gamma, struct drop_state *ds) {
-	// Arranged as bits to facilitate subdividing again if a subdivided file is still huge
-	int splitbits = log(splits) / log(2);
+	// Arranged as bits to facilitate subdividing again if a subdivided file is still huge.
+	//
+	// There must be at least two buckets: with only one, each subdivision would
+	// consume no bits of the index, so it would never reach the maximum prefix
+	// that stops the recursion, and the shift below would be by the full width
+	// of the index, which is undefined.
+	int splitbits = 1;
+	if (splits > 1) {
+		splitbits = log(splits) / log(2);
+	}
 	splits = 1 << splitbits;
 
 	FILE *geomfiles[splits];
@@ -890,7 +898,14 @@ void radix1(int *geomfds_in, int *indexfds_in, int inputs, int prefix, int split
 		}
 
 		if (indexst.st_size > 0) {
-			if (indexst.st_size + geomst.st_size < mem) {
+			// Subdividing again would only make progress if the next level could
+			// split into at least two buckets, which it can't if there are no longer
+			// enough files left to do it with. In that case, sort in memory instead,
+			// even though this is more memory than we wanted to use at once, since
+			// it is the only way left to get this bucket sorted.
+			bool can_subdivide = *availfiles / 4 > 1;
+
+			if (indexst.st_size + geomst.st_size < mem || !can_subdivide) {
 				std::atomic<long long> indexpos(indexst.st_size);
 				int bytes = sizeof(struct index);
 


### PR DESCRIPTION
`--prefer-radix-sort` is broken on `main`. It sets the memory limit to 8K, which `radix()` halves again, so the radix subdivision in `radix1()` actually has to recurse to get each bucket under 4K — and it fails on most of the existing test inputs, either by desynchronizing the geometry stream or by segfaulting. Two independent bugs, plus a test that would have caught both.

Supersedes #403. Contains no duplicate-geometry handling; #402 is independent of this.

## 1. An extra byte when a bucket is written directly

`radix1()` writes out a sorted bucket in two places. `merge()` writes all but the last byte of each serialized feature and then appends the byte for the feature minzoom, since the minzoom *is* the last byte of the feature. The path taken when a bucket holds only one feature, or when the recursion has consumed every bit of the index, instead writes the feature's whole serialized length and *then* appends another minzoom byte — one byte more than the feature's length prefix claims. Everything read from the geometry afterward is misaligned.

```
$ ./tippecanoe -q -f -o out.mbtiles -z4 -aR tests/ne_110m_ocean/in.json
wrong length decoding feature: used 10, len is 33
```

Fixed by writing one byte less, as `merge()` does.

## 2. Recursing forever once the files run out

`radix1()` stops recursing when `prefix + splitbits` reaches the width of the index. The bucket count comes from the number of files still available, which shrinks at every level. Instrumenting the descent on `tests/feature-filter/in.json`:

```
radix1 prefix=0  splits=256 splitbits=8 availfiles=1482
radix1 prefix=8  splits=256 splitbits=8 availfiles=1126
...
radix1 prefix=61 splits=2   splitbits=1 availfiles=10
radix1 prefix=62 splits=2   splitbits=1 availfiles=8
radix1 prefix=63 splits=1   splitbits=0 availfiles=6     <-- fixed point
radix1 prefix=63 splits=1   splitbits=0 availfiles=6
...
```

Once `availfiles / 4` reaches 1, `splitbits` is 0: the recursion consumes no index bits and `availfiles` stops shrinking too, so `prefix` never advances. About 6900 levels deep before the stack ran out.

`splitbits == 0` is also undefined behavior, because

```c
unsigned long long which = (ix.ix << prefix) >> (64 - splitbits);
```

becomes a shift by the full width of the value. What it does in practice is mask the shift count down to zero, so `which` comes out as the whole shifted index rather than 0, and both arrays indexed by it are then addressed far out of bounds — `geomfiles[which]` is written through as a `FILE *`, and `sub_geompos[which]` gets a read-modify-write inside `fwrite_check`. On this input the surviving indices happen to be even, so `ix.ix << 63` is 0 and the stack runs out first; an odd index there is what turns it into memory corruption.

Fixed by requiring at least two buckets, so every subdivision consumes at least one index bit and the shift stays in range, and by not recursing at all when the next level wouldn't have enough files to split with. That bucket is sorted in memory instead, over the budget, because it's the only way left to get it sorted — the limit exists to avoid thrashing, not for correctness, and the alternative is not finishing. Normal runs can't reach it: `mem` ends up as half the available memory rather than 4K, so it would take on the order of thirteen levels.

## 3. A differential test

The result of a sort shouldn't depend on how the sort was performed, so rather than checking sorted output against a committed copy, `radix-sort-test` checks that `-aR` produces the same tiles as sorting in memory. Same shape as the existing `parallel-test`, which compares `linear-file.json` against `parallel-file.json` instead of a golden file. Nothing new to keep up to date, and the comparison holds however deep the recursion happens to go on a given machine, since both runs are on the same machine.

What sends the sort down the rarely-taken branches is the *shape* of the input, not the size, so the two purpose-built inputs are small and adversarial:

* `bigfeatures.json` — eight well-separated 2000-point linestrings, each bigger than the lowered limit on its own, so each is written out as a bucket of one.
* `onelocation.json` — 500 points at identical coordinates, sharing the whole index, so they must be subdivided until no bits remain.

Then `tests/feature-filter`, `tests/ne_110m_ocean`, `tests/border`, `tests/loop`, `tests/tl_2022_11_tract`, and `tests/epsg-3857` for breadth. Instrumenting which branch is taken confirms all three are covered:

```
bigfeatures.json      8 direct-write single-feature   prefix=0
onelocation.json      1 direct-write prefix-exhausted prefix=60
feature-filter/in     1 direct-write prefix-exhausted prefix=59
                      3 memory-sort
                      1 memory-sort (no files left)      <-- the fallback added above
```

An earlier version of `bigfeatures.json` had a single feature and passed on `main` even though it did reach the buggy path: with only one feature in the whole tileset the stray byte lands right before the EOF marker and happens to be zero, so it reads as EOF and the corruption is invisible. It needs a following record to desync against, hence eight rather than one.

Runs in about ten seconds. Wired into `test` and into `fewer-tests` — the latter because the out-of-bounds write in bug 2 is exactly what that build's address sanitizer is for.

## Verification

Each fix on its own, `-z4 -aR`:

| input | `main` | + bug 1 fix | + both fixes |
| --- | --- | --- | --- |
| `tests/ne_110m_ocean/in.json` | `wrong length` | ok | ok |
| `tests/border/in.json` | `wrong length` | ok | ok |
| `tests/epsg-3857/in.json` | `wrong length` | ok | ok |
| `tests/loop/in.json` | `wrong length` | ok | ok |
| `tests/tl_2022_11_tract/in.json.gz` | `wrong length` | ok | ok |
| `tests/feature-filter/in.json` | segfault | segfault | ok |

With both, every one of them produces output byte-identical to the ordinary in-memory sort. `make test` passes, including the new target.

## Not included

I left out the `TIPPECANOE_SORT_MEMORY` / `TIPPECANOE_MAX_FILES` overrides discussed earlier. They aren't needed here — `-aR` is enough of a lever and the comparison is machine-independent regardless — but they'd let a test sweep several budgets and pin the recursion depth by construction instead of inheriting it from `ulimit -n`. Happy to do that separately.