### PR TITLE
Make MLT a full input and output format for tippecanoe-decode, tile-join, and tippecanoe-overzoom

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,12 @@ jobs:
         run: brew install sqlite3
       - run: uname -a; BUILDTYPE=${{ matrix.version }} make
       - run: make test
+
+  test-without-mlt:
+    runs-on: ubuntu-latest
+    steps:
+      # No submodules: the MLT=0 build must not need them
+      - uses: actions/checkout@v3
+      - run: sudo apt-get install libsqlite3-dev
+      - run: uname -a; make MLT=0
+      - run: make MLT=0 test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         version: ['Release', 'Debug']
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
         run: sudo apt-get install libsqlite3-dev

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ tests/**/*.geobuf
 tests/mlt/dir-out/
 tests/mlt/roundtrip-dir/
 tests/mlt/overzoom.pbf
+tests/mlt/join-out-dir/
+tests/mlt/mvt-source-dir/
+tests/mlt/overzoom-out.mlt
 
 mlt-build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ tests/**/*.mbtiles
 tests/**/*.check
 tests/**/*.geobuf
 
+# MLT build directory
+mlt-build/
+
 # Vim
 *.swp
 
@@ -51,3 +54,4 @@ tests/**/*.geobuf
 
 # Nodejs
 node_modules
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ tests/**/*.mbtiles
 tests/**/*.check
 tests/**/*.geobuf
 
-# MLT build directory
 mlt-build/
 
 # Vim

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ unit
 tests/**/*.mbtiles
 tests/**/*.check
 tests/**/*.geobuf
+tests/mlt/dir-out/
+tests/mlt/roundtrip-dir/
+tests/mlt/overzoom.pbf
 
 mlt-build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ mlt-build/
 
 # Nodejs
 node_modules
-tmp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "maplibre-tile-spec"]
 	path = maplibre-tile-spec
-	url = https://github.com/dannote/maplibre-tile-spec.git
-	branch = feature/cpp-encoder
+	url = https://github.com/maplibre/maplibre-tile-spec.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "maplibre-tile-spec"]
 	path = maplibre-tile-spec
 	url = https://github.com/maplibre/maplibre-tile-spec.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "maplibre-tile-spec"]
+	path = maplibre-tile-spec
+	url = https://github.com/dannote/maplibre-tile-spec.git
+	branch = feature/cpp-encoder

--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,16 @@ tippecanoe-enumerate: enumerate.o
 tippecanoe-decode: decode.o projection.o mvt.o mlt_decode.o write_json.o text.o jsonpull/jsonpull.o dirtiles.o pmtiles_file.o $(MLT_DECODE_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3
 
-tile-join: tile-join.o platform.o projection.o mbtiles.o mvt.o mlt_decode.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o pmtiles_file.o clip.o attribute.o thread.o read_json.o clipper2/src/clipper.engine.o $(MLT_DECODE_LIBS)
+tile-join: tile-join.o platform.o projection.o mbtiles.o mvt.o mlt.o mlt_decode.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o pmtiles_file.o clip.o attribute.o thread.o read_json.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-json-tool: jsontool.o jsonpull/jsonpull.o csv.o text.o geojson-loop.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
-unit: unit.o text.o sort.o mvt.o mlt_decode.o projection.o clip.o attribute.o jsonpull/jsonpull.o evaluator.o read_json.o clipper2/src/clipper.engine.o $(MLT_DECODE_LIBS)
+unit: unit.o text.o sort.o mvt.o mlt.o mlt_decode.o projection.o clip.o attribute.o jsonpull/jsonpull.o evaluator.o read_json.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
-tippecanoe-overzoom: overzoom.o mvt.o mlt_decode.o clip.o evaluator.o jsonpull/jsonpull.o text.o attribute.o read_json.o projection.o read_json.o clipper2/src/clipper.engine.o $(MLT_DECODE_LIBS)
+tippecanoe-overzoom: overzoom.o mvt.o mlt.o mlt_decode.o clip.o evaluator.o jsonpull/jsonpull.o text.o attribute.o read_json.o projection.o read_json.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 -include $(wildcard *.d)
@@ -119,7 +119,7 @@ indent:
 TESTS = $(wildcard tests/*/out/*.json)
 SPACE = $(NULL) $(NULL)
 
-test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test mlt-test mlt-decode-test
+test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test mlt-test mlt-decode-test mlt-output-test
 	./unit
 
 suffixes = json json.gz
@@ -649,6 +649,29 @@ mlt-decode-test: tippecanoe tippecanoe-decode tile-join tippecanoe-overzoom
 	rm -f tests/mlt/joined.mbtiles tests/mlt/joined.mbtiles.json.check
 	rm -f tests/mlt/roundtrip-dir.json.check tests/mlt/overzoom.pbf tests/mlt/overzoom.json.check
 	rm -rf tests/mlt/roundtrip-dir
+
+mlt-output-test: tippecanoe tippecanoe-decode tile-join tippecanoe-overzoom
+	./tippecanoe -q -z5 -f -o tests/mlt/mvt-source.mbtiles tests/mlt/roundtrip.geojson
+	# tile-join writes MLT tiles to an mbtiles file, whatever the sources are encoded in
+	./tile-join -f --output-format=mlt -o tests/mlt/join-out.mbtiles tests/mlt/mvt-source.mbtiles
+	./tippecanoe-decode -x generator -x generator_options tests/mlt/join-out.mbtiles > tests/mlt/join-out.mbtiles.json.check
+	cmp tests/mlt/join-out.mbtiles.json.check tests/mlt/join-out.mbtiles.json
+	# tile-join writes MLT tiles to a tile directory
+	rm -rf tests/mlt/join-out-dir
+	./tile-join -f --output-format=mlt -e tests/mlt/join-out-dir tests/mlt/mvt-source.mbtiles
+	@test $$(find tests/mlt/join-out-dir -name '*.mlt' | wc -l) -gt 0 || (echo "FAIL: No .mlt files in tile-join directory output" && exit 1)
+	@test $$(find tests/mlt/join-out-dir -name '*.pbf' | wc -l) -eq 0 || (echo "FAIL: .pbf files in tile-join MLT directory output" && exit 1)
+	# tippecanoe-overzoom writes MLT tiles
+	rm -rf tests/mlt/mvt-source-dir
+	./tippecanoe -q -z5 -f -e tests/mlt/mvt-source-dir tests/mlt/roundtrip.geojson
+	# The same features come out whichever direction the formats are converted in,
+	# so this is compared against the standard for overzooming an MLT tile to MVT
+	./tippecanoe-overzoom --output-format=mlt -o tests/mlt/overzoom-out.mlt tests/mlt/mvt-source-dir/2/0/1.pbf 2/0/1 4/2/6
+	./tippecanoe-decode tests/mlt/overzoom-out.mlt 4 2 6 > tests/mlt/overzoom-out.json.check
+	cmp tests/mlt/overzoom-out.json.check tests/mlt/overzoom.json
+	rm -f tests/mlt/mvt-source.mbtiles tests/mlt/join-out.mbtiles tests/mlt/join-out.mbtiles.json.check
+	rm -f tests/mlt/overzoom-out.mlt tests/mlt/overzoom-out.json.check
+	rm -rf tests/mlt/join-out-dir tests/mlt/mvt-source-dir
 
 # Use this target to regenerate the standards that the tests are compared against
 # after making a change that legitimately changes their output

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,9 @@ H = $(wildcard *.h) $(wildcard *.hpp)
 C = $(wildcard *.c) $(wildcard *.cpp)
 
 INCLUDES = -I/usr/local/include -I. -Iclipper2/include
-MLT_INCLUDES = -Imaplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
-MLT_LIBS = mlt-build/libmlt-cpp-encoder.a mlt-build/libfsst-lib.a mlt-build/fastpfor/libFastPFOR.a
+MLT_INCLUDES = -isystem maplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
+MLT_DECODE_LIBS = mlt-build/libmlt-cpp.a mlt-build/libfsst-lib.a mlt-build/fastpfor/libFastPFOR.a
+MLT_LIBS = mlt-build/libmlt-cpp-encoder.a $(MLT_DECODE_LIBS)
 MLT_BUILD_STAMP = mlt-build/.built
 LIBS = -L/usr/local/lib
 
@@ -72,30 +73,30 @@ $(MLT_BUILD_STAMP): maplibre-tile-spec/cpp/CMakeLists.txt
 		-DMLT_WITH_TOOLS=OFF \
 		-DCMAKE_CXX_STANDARD=20 \
 		$(if $(VERBOSE),,--log-level=WARNING) > /dev/null
-	cmake --build mlt-build --target mlt-cpp-encoder $(if $(VERBOSE),,-- -s) > /dev/null
+	cmake --build mlt-build --target mlt-cpp mlt-cpp-encoder $(if $(VERBOSE),,-- -s) > /dev/null
 	touch $@
 
 $(MLT_LIBS): $(MLT_BUILD_STAMP)
 
-tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o mlt.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o $(MLT_LIBS)
+tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o mlt.o mlt_decode.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-enumerate: enumerate.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lsqlite3
 
-tippecanoe-decode: decode.o projection.o mvt.o write_json.o text.o jsonpull/jsonpull.o dirtiles.o pmtiles_file.o
+tippecanoe-decode: decode.o projection.o mvt.o mlt_decode.o write_json.o text.o jsonpull/jsonpull.o dirtiles.o pmtiles_file.o $(MLT_DECODE_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3
 
-tile-join: tile-join.o platform.o projection.o mbtiles.o mvt.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o pmtiles_file.o clip.o attribute.o thread.o read_json.o clipper2/src/clipper.engine.o
+tile-join: tile-join.o platform.o projection.o mbtiles.o mvt.o mlt_decode.o memfile.o dirtiles.o jsonpull/jsonpull.o text.o evaluator.o csv.o write_json.o pmtiles_file.o clip.o attribute.o thread.o read_json.o clipper2/src/clipper.engine.o $(MLT_DECODE_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-json-tool: jsontool.o jsonpull/jsonpull.o csv.o text.o geojson-loop.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
-unit: unit.o text.o sort.o mvt.o projection.o clip.o attribute.o jsonpull/jsonpull.o evaluator.o read_json.o clipper2/src/clipper.engine.o
+unit: unit.o text.o sort.o mvt.o mlt_decode.o projection.o clip.o attribute.o jsonpull/jsonpull.o evaluator.o read_json.o clipper2/src/clipper.engine.o $(MLT_DECODE_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
-tippecanoe-overzoom: overzoom.o mvt.o clip.o evaluator.o jsonpull/jsonpull.o text.o attribute.o read_json.o projection.o read_json.o clipper2/src/clipper.engine.o
+tippecanoe-overzoom: overzoom.o mvt.o mlt_decode.o clip.o evaluator.o jsonpull/jsonpull.o text.o attribute.o read_json.o projection.o read_json.o clipper2/src/clipper.engine.o $(MLT_DECODE_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 -include $(wildcard *.d)
@@ -103,7 +104,7 @@ tippecanoe-overzoom: overzoom.o mvt.o clip.o evaluator.o jsonpull/jsonpull.o tex
 %.o: %.c
 	$(CC) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CFLAGS) -c -o $@ $<
 
-mlt.o: mlt.cpp mlt-build/libmlt-cpp-encoder.a
+mlt.o mlt_decode.o: %.o: %.cpp $(MLT_BUILD_STAMP)
 	$(CXX) -MMD $(PG) $(INCLUDES) $(MLT_INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) -std=c++20 -c -o $@ $<
 
 %.o: %.cpp
@@ -118,7 +119,7 @@ indent:
 TESTS = $(wildcard tests/*/out/*.json)
 SPACE = $(NULL) $(NULL)
 
-test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test mlt-test
+test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test mlt-test mlt-decode-test
 	./unit
 
 suffixes = json json.gz
@@ -625,6 +626,29 @@ mlt-test: tippecanoe
 	@test $$(sqlite3 tests/mlt/points-tess.mbtiles "SELECT COUNT(*) FROM tiles") -gt 0 || (echo "FAIL: No tiles with pretessellate" && exit 1)
 	rm -f tests/mlt/points.mbtiles tests/mlt/points-mvt.mbtiles tests/mlt/points-tess.mbtiles
 	rm -rf tests/mlt/dir-out
+
+mlt-decode-test: tippecanoe tippecanoe-decode tile-join tippecanoe-overzoom
+	# tippecanoe-decode reads MLT tiles out of an mbtiles file
+	./tippecanoe -q --output-format=mlt -z5 -f -o tests/mlt/roundtrip.mbtiles tests/mlt/roundtrip.geojson
+	./tippecanoe-decode -x generator -x generator_options tests/mlt/roundtrip.mbtiles > tests/mlt/roundtrip.mbtiles.json.check
+	cmp tests/mlt/roundtrip.mbtiles.json.check tests/mlt/roundtrip.mbtiles.json
+	# tile-join reads MLT tiles and writes MVT tiles
+	./tile-join -f -o tests/mlt/joined.mbtiles tests/mlt/roundtrip.mbtiles
+	./tippecanoe-decode -x generator -x generator_options tests/mlt/joined.mbtiles > tests/mlt/joined.mbtiles.json.check
+	cmp tests/mlt/joined.mbtiles.json.check tests/mlt/joined.mbtiles.json
+	# tippecanoe-decode reads MLT tiles out of a tile directory
+	rm -rf tests/mlt/roundtrip-dir
+	./tippecanoe -q --output-format=mlt -z5 -f -e tests/mlt/roundtrip-dir tests/mlt/roundtrip.geojson
+	./tippecanoe-decode -x generator -x generator_options tests/mlt/roundtrip-dir > tests/mlt/roundtrip-dir.json.check
+	cmp tests/mlt/roundtrip-dir.json.check tests/mlt/roundtrip-dir.json
+	# tippecanoe-overzoom reads a single MLT tile
+	./tippecanoe-overzoom -o tests/mlt/overzoom.pbf tests/mlt/roundtrip-dir/2/0/1.mlt 2/0/1 4/2/6
+	./tippecanoe-decode tests/mlt/overzoom.pbf 4 2 6 > tests/mlt/overzoom.json.check
+	cmp tests/mlt/overzoom.json.check tests/mlt/overzoom.json
+	rm -f tests/mlt/roundtrip.mbtiles tests/mlt/roundtrip.mbtiles.json.check
+	rm -f tests/mlt/joined.mbtiles tests/mlt/joined.mbtiles.json.check
+	rm -f tests/mlt/roundtrip-dir.json.check tests/mlt/overzoom.pbf tests/mlt/overzoom.json.check
+	rm -rf tests/mlt/roundtrip-dir
 
 # Use this target to regenerate the standards that the tests are compared against
 # after making a change that legitimately changes their output

--- a/Makefile
+++ b/Makefile
@@ -606,20 +606,15 @@ layer-json-test: tippecanoe tippecanoe-decode
 	rm -f tests/layer-json/out.mbtiles.json.check tests/layer-json/out.mbtiles
 
 mlt-test: tippecanoe
-	# Points: MLT output, verify tile count matches MVT
 	./tippecanoe -q --output-format=mlt -z5 -f -o tests/mlt/points.mbtiles tests/mlt/points.geojson
 	./tippecanoe -q -z5 -f -o tests/mlt/points-mvt.mbtiles tests/mlt/points.geojson
 	@test $$(sqlite3 tests/mlt/points.mbtiles "SELECT COUNT(*) FROM tiles") -eq $$(sqlite3 tests/mlt/points-mvt.mbtiles "SELECT COUNT(*) FROM tiles") || (echo "FAIL: MLT and MVT tile counts differ" && exit 1)
-	# Verify format metadata
 	@test "$$(sqlite3 tests/mlt/points.mbtiles "SELECT value FROM metadata WHERE name='format'")" = "mlt" || (echo "FAIL: format metadata is not 'mlt'" && exit 1)
-	# Verify tiles are gzip compressed
 	@sqlite3 tests/mlt/points.mbtiles "SELECT hex(substr(tile_data, 1, 2)) FROM tiles LIMIT 1" | grep -q "1F8B" || (echo "FAIL: MLT tiles not gzip compressed" && exit 1)
-	# Directory output with .mlt extension
 	rm -rf tests/mlt/dir-out
 	./tippecanoe -q --output-format=mlt -z2 -f -e tests/mlt/dir-out tests/mlt/points.geojson
 	@test $$(find tests/mlt/dir-out -name '*.mlt' | wc -l) -gt 0 || (echo "FAIL: No .mlt files in directory output" && exit 1)
 	@test $$(find tests/mlt/dir-out -name '*.pbf' | wc -l) -eq 0 || (echo "FAIL: .pbf files in MLT directory output" && exit 1)
-	# Pretessellate flag
 	./tippecanoe -q --output-format=mlt --pretessellate -z5 -f -o tests/mlt/points-tess.mbtiles tests/mlt/points.geojson
 	@test $$(sqlite3 tests/mlt/points-tess.mbtiles "SELECT COUNT(*) FROM tiles") -gt 0 || (echo "FAIL: No tiles with pretessellate" && exit 1)
 	rm -f tests/mlt/points.mbtiles tests/mlt/points-mvt.mbtiles tests/mlt/points-tess.mbtiles

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,22 @@ H = $(wildcard *.h) $(wildcard *.hpp)
 C = $(wildcard *.c) $(wildcard *.cpp)
 
 INCLUDES = -I/usr/local/include -I. -Iclipper2/include
+MLT_INCLUDES = -Imaplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
+MLT_LIBS = mlt-build/libmlt-cpp-encoder.a mlt-build/libfsst-lib.a
 LIBS = -L/usr/local/lib
 
-tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o
+mlt-build/libmlt-cpp-encoder.a: maplibre-tile-spec/cpp/CMakeLists.txt
+	cmake -S maplibre-tile-spec/cpp -B mlt-build \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DMLT_WITH_FASTPFOR=OFF \
+		-DMLT_WITH_JSON=OFF \
+		-DMLT_WITH_TESTS=OFF \
+		-DMLT_WITH_TOOLS=OFF \
+		-DCMAKE_CXX_STANDARD=20 \
+		$(if $(VERBOSE),,--log-level=WARNING) > /dev/null
+	cmake --build mlt-build --target mlt-cpp-encoder $(if $(VERBOSE),,-- -s) > /dev/null
+
+tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o mlt.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
 
 tippecanoe-enumerate: enumerate.o
@@ -85,11 +98,14 @@ tippecanoe-overzoom: overzoom.o mvt.o clip.o evaluator.o jsonpull/jsonpull.o tex
 %.o: %.c
 	$(CC) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CFLAGS) -c -o $@ $<
 
+mlt.o: mlt.cpp mlt-build/libmlt-cpp-encoder.a
+	$(CXX) -MMD $(PG) $(INCLUDES) $(MLT_INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) -std=c++20 -c -o $@ $<
+
 %.o: %.cpp
 	$(CXX) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) -c -o $@ $<
 
 clean:
-	rm -f ./tippecanoe ./tippecanoe-* ./tile-join ./unit *.o *.d */*.o */*.d tests/**/*.mbtiles tests/**/*.check
+	rm -rf ./tippecanoe ./tippecanoe-* ./tile-join ./unit *.o *.d */*.o */*.d tests/**/*.mbtiles tests/**/*.check mlt-build
 
 indent:
 	clang-format -i -style="{BasedOnStyle: Google, IndentWidth: 8, UseTab: Always, AllowShortIfStatementsOnASingleLine: false, ColumnLimit: 0, ContinuationIndentWidth: 8, SpaceAfterCStyleCast: true, IndentCaseLabels: false, AllowShortBlocksOnASingleLine: false, AllowShortFunctionsOnASingleLine: false, SortIncludes: false}" $(filter-out flatgeobuf.cpp,$(C)) $(H) jsonpull/*.[ch]
@@ -97,7 +113,7 @@ indent:
 TESTS = $(wildcard tests/*/out/*.json)
 SPACE = $(NULL) $(NULL)
 
-test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test
+test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test mlt-test
 	./unit
 
 suffixes = json json.gz
@@ -583,6 +599,31 @@ layer-json-test: tippecanoe tippecanoe-decode
 	./tippecanoe-decode -x generator -x generator_options tests/layer-json/out.mbtiles > tests/layer-json/out.mbtiles.json.check
 	cmp tests/layer-json/out.mbtiles.json.check tests/layer-json/out.mbtiles.json
 	rm -f tests/layer-json/out.mbtiles.json.check tests/layer-json/out.mbtiles
+
+mlt-test: tippecanoe
+	# Points: MLT output, verify tile count matches MVT
+	./tippecanoe -q --output-format=mlt -z5 -f -o tests/mlt/points.mbtiles tests/mlt/points.geojson
+	./tippecanoe -q -z5 -f -o tests/mlt/points-mvt.mbtiles tests/mlt/points.geojson
+	@test $$(sqlite3 tests/mlt/points.mbtiles "SELECT COUNT(*) FROM tiles") -eq $$(sqlite3 tests/mlt/points-mvt.mbtiles "SELECT COUNT(*) FROM tiles") || (echo "FAIL: MLT and MVT tile counts differ" && exit 1)
+	@echo "PASS: MLT tile count matches MVT"
+	# Verify format metadata
+	@test "$$(sqlite3 tests/mlt/points.mbtiles "SELECT value FROM metadata WHERE name='format'")" = "mlt" || (echo "FAIL: format metadata is not 'mlt'" && exit 1)
+	@echo "PASS: MLT format metadata correct"
+	# Verify tiles are gzip compressed
+	@sqlite3 tests/mlt/points.mbtiles "SELECT hex(substr(tile_data, 1, 2)) FROM tiles LIMIT 1" | grep -q "1F8B" || (echo "FAIL: MLT tiles not gzip compressed" && exit 1)
+	@echo "PASS: MLT tiles are gzip compressed"
+	# Directory output with .mlt extension
+	rm -rf tests/mlt/dir-out
+	./tippecanoe -q --output-format=mlt -z2 -f -e tests/mlt/dir-out tests/mlt/points.geojson
+	@test $$(find tests/mlt/dir-out -name '*.mlt' | wc -l) -gt 0 || (echo "FAIL: No .mlt files in directory output" && exit 1)
+	@test $$(find tests/mlt/dir-out -name '*.pbf' | wc -l) -eq 0 || (echo "FAIL: .pbf files in MLT directory output" && exit 1)
+	@echo "PASS: Directory output uses .mlt extension"
+	# Pretessellate flag
+	./tippecanoe -q --output-format=mlt --pretessellate -z5 -f -o tests/mlt/points-tess.mbtiles tests/mlt/points.geojson
+	@test $$(sqlite3 tests/mlt/points-tess.mbtiles "SELECT COUNT(*) FROM tiles") -gt 0 || (echo "FAIL: No tiles with pretessellate" && exit 1)
+	@echo "PASS: --pretessellate produces tiles"
+	rm -f tests/mlt/points.mbtiles tests/mlt/points-mvt.mbtiles tests/mlt/points-tess.mbtiles
+	rm -rf tests/mlt/dir-out
 
 # Use this target to regenerate the standards that the tests are compared against
 # after making a change that legitimately changes their output

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ MLT_FLAGS =
 MLT_INCLUDES = -isystem maplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
 MLT_STD = -std=c++20
 MLT_DEPS = $(MLT_BUILD_STAMP)
-MLT_DECODE_LIBS = mlt-build/libmlt-cpp.a mlt-build/libfsst-lib.a mlt-build/fastpfor/libFastPFOR.a
+MLT_DECODE_LIBS = mlt-build/libmlt-cpp.a mlt-build/libfsst-lib.a mlt-build/libfastpfor-lib.a
 MLT_LIBS = mlt-build/libmlt-cpp-encoder.a $(MLT_DECODE_LIBS)
 MLT_TESTS = mlt-test mlt-decode-test mlt-output-test
 endif
@@ -86,8 +86,6 @@ LIBS = -L/usr/local/lib
 $(MLT_BUILD_STAMP): maplibre-tile-spec/cpp/CMakeLists.txt
 	cmake -S maplibre-tile-spec/cpp -B mlt-build \
 		-DCMAKE_BUILD_TYPE=$(BUILDTYPE) \
-		-DMLT_WITH_FASTPFOR=ON \
-		-DMLT_WITH_FASTPFOR_SIMD=OFF \
 		-DMLT_WITH_JSON=OFF \
 		-DMLT_WITH_TESTS=OFF \
 		-DMLT_WITH_TOOLS=OFF \

--- a/Makefile
+++ b/Makefile
@@ -58,19 +58,24 @@ C = $(wildcard *.c) $(wildcard *.cpp)
 
 INCLUDES = -I/usr/local/include -I. -Iclipper2/include
 MLT_INCLUDES = -Imaplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
-MLT_LIBS = mlt-build/libmlt-cpp-encoder.a mlt-build/libfsst-lib.a
+MLT_LIBS = mlt-build/libmlt-cpp-encoder.a mlt-build/libfsst-lib.a mlt-build/fastpfor/libFastPFOR.a
+MLT_BUILD_STAMP = mlt-build/.built
 LIBS = -L/usr/local/lib
 
-mlt-build/libmlt-cpp-encoder.a: maplibre-tile-spec/cpp/CMakeLists.txt
+$(MLT_BUILD_STAMP): maplibre-tile-spec/cpp/CMakeLists.txt
 	cmake -S maplibre-tile-spec/cpp -B mlt-build \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DMLT_WITH_FASTPFOR=OFF \
+		-DCMAKE_BUILD_TYPE=$(BUILDTYPE) \
+		-DMLT_WITH_FASTPFOR=ON \
+		-DMLT_WITH_FASTPFOR_SIMD=OFF \
 		-DMLT_WITH_JSON=OFF \
 		-DMLT_WITH_TESTS=OFF \
 		-DMLT_WITH_TOOLS=OFF \
 		-DCMAKE_CXX_STANDARD=20 \
 		$(if $(VERBOSE),,--log-level=WARNING) > /dev/null
 	cmake --build mlt-build --target mlt-cpp-encoder $(if $(VERBOSE),,-- -s) > /dev/null
+	touch $@
+
+$(MLT_LIBS): $(MLT_BUILD_STAMP)
 
 tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o mlt.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
@@ -605,23 +610,18 @@ mlt-test: tippecanoe
 	./tippecanoe -q --output-format=mlt -z5 -f -o tests/mlt/points.mbtiles tests/mlt/points.geojson
 	./tippecanoe -q -z5 -f -o tests/mlt/points-mvt.mbtiles tests/mlt/points.geojson
 	@test $$(sqlite3 tests/mlt/points.mbtiles "SELECT COUNT(*) FROM tiles") -eq $$(sqlite3 tests/mlt/points-mvt.mbtiles "SELECT COUNT(*) FROM tiles") || (echo "FAIL: MLT and MVT tile counts differ" && exit 1)
-	@echo "PASS: MLT tile count matches MVT"
 	# Verify format metadata
 	@test "$$(sqlite3 tests/mlt/points.mbtiles "SELECT value FROM metadata WHERE name='format'")" = "mlt" || (echo "FAIL: format metadata is not 'mlt'" && exit 1)
-	@echo "PASS: MLT format metadata correct"
 	# Verify tiles are gzip compressed
 	@sqlite3 tests/mlt/points.mbtiles "SELECT hex(substr(tile_data, 1, 2)) FROM tiles LIMIT 1" | grep -q "1F8B" || (echo "FAIL: MLT tiles not gzip compressed" && exit 1)
-	@echo "PASS: MLT tiles are gzip compressed"
 	# Directory output with .mlt extension
 	rm -rf tests/mlt/dir-out
 	./tippecanoe -q --output-format=mlt -z2 -f -e tests/mlt/dir-out tests/mlt/points.geojson
 	@test $$(find tests/mlt/dir-out -name '*.mlt' | wc -l) -gt 0 || (echo "FAIL: No .mlt files in directory output" && exit 1)
 	@test $$(find tests/mlt/dir-out -name '*.pbf' | wc -l) -eq 0 || (echo "FAIL: .pbf files in MLT directory output" && exit 1)
-	@echo "PASS: Directory output uses .mlt extension"
 	# Pretessellate flag
 	./tippecanoe -q --output-format=mlt --pretessellate -z5 -f -o tests/mlt/points-tess.mbtiles tests/mlt/points.geojson
 	@test $$(sqlite3 tests/mlt/points-tess.mbtiles "SELECT COUNT(*) FROM tiles") -gt 0 || (echo "FAIL: No tiles with pretessellate" && exit 1)
-	@echo "PASS: --pretessellate produces tiles"
 	rm -f tests/mlt/points.mbtiles tests/mlt/points-mvt.mbtiles tests/mlt/points-tess.mbtiles
 	rm -rf tests/mlt/dir-out
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,36 @@ BUILDTYPE ?= Release
 BUILD_INFO ?=
 SHELL = /bin/sh
 
+# MapLibre Tile support requires the maplibre-tile-spec submodule and cmake
+# to build it. Use `make MLT=0` for a build with no dependencies beyond the
+# ones that Mapbox Vector Tiles need; it can neither read nor write MLT.
+MLT ?= 1
+
+MLT_BUILD_STAMP = mlt-build/.built
+
+ifeq ($(MLT),0)
+MLT_FLAGS = -DNO_MLT
+MLT_INCLUDES =
+MLT_STD =
+MLT_DEPS =
+MLT_DECODE_LIBS =
+MLT_LIBS =
+MLT_TESTS =
+else
+MLT_FLAGS =
+MLT_INCLUDES = -isystem maplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
+MLT_STD = -std=c++20
+MLT_DEPS = $(MLT_BUILD_STAMP)
+MLT_DECODE_LIBS = mlt-build/libmlt-cpp.a mlt-build/libfsst-lib.a mlt-build/fastpfor/libFastPFOR.a
+MLT_LIBS = mlt-build/libmlt-cpp-encoder.a $(MLT_DECODE_LIBS)
+MLT_TESTS = mlt-test mlt-decode-test mlt-output-test
+endif
 
 # inherit from env if set
 CC := $(CC)
 CXX := $(CXX)
 CFLAGS := $(CFLAGS) -fPIE -DBUILD_INFO=$(BUILD_INFO)
-CXXFLAGS := $(CXXFLAGS) -std=c++17 -fPIE -DBUILD_INFO=$(BUILD_INFO)
+CXXFLAGS := $(CXXFLAGS) -std=c++17 -fPIE -DBUILD_INFO=$(BUILD_INFO) $(MLT_FLAGS)
 LDFLAGS := $(LDFLAGS)
 WARNING_FLAGS := -Wall -Wshadow -Wsign-compare -Wextra -Wunreachable-code -Wuninitialized -Wshadow
 RELEASE_FLAGS := -O3 -DNDEBUG
@@ -57,10 +81,6 @@ H = $(wildcard *.h) $(wildcard *.hpp)
 C = $(wildcard *.c) $(wildcard *.cpp)
 
 INCLUDES = -I/usr/local/include -I. -Iclipper2/include
-MLT_INCLUDES = -isystem maplibre-tile-spec/cpp/include -isystem maplibre-tile-spec/cpp/vendor/fsst
-MLT_DECODE_LIBS = mlt-build/libmlt-cpp.a mlt-build/libfsst-lib.a mlt-build/fastpfor/libFastPFOR.a
-MLT_LIBS = mlt-build/libmlt-cpp-encoder.a $(MLT_DECODE_LIBS)
-MLT_BUILD_STAMP = mlt-build/.built
 LIBS = -L/usr/local/lib
 
 $(MLT_BUILD_STAMP): maplibre-tile-spec/cpp/CMakeLists.txt
@@ -76,7 +96,9 @@ $(MLT_BUILD_STAMP): maplibre-tile-spec/cpp/CMakeLists.txt
 	cmake --build mlt-build --target mlt-cpp mlt-cpp-encoder $(if $(VERBOSE),,-- -s) > /dev/null
 	touch $@
 
+ifneq ($(MLT),0)
 $(MLT_LIBS): $(MLT_BUILD_STAMP)
+endif
 
 tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o mlt.o mlt_decode.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o $(MLT_LIBS)
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread
@@ -104,8 +126,8 @@ tippecanoe-overzoom: overzoom.o mvt.o mlt.o mlt_decode.o clip.o evaluator.o json
 %.o: %.c
 	$(CC) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CFLAGS) -c -o $@ $<
 
-mlt.o mlt_decode.o: %.o: %.cpp $(MLT_BUILD_STAMP)
-	$(CXX) -MMD $(PG) $(INCLUDES) $(MLT_INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) -std=c++20 -c -o $@ $<
+mlt.o mlt_decode.o: %.o: %.cpp $(MLT_DEPS)
+	$(CXX) -MMD $(PG) $(INCLUDES) $(MLT_INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) $(MLT_STD) -c -o $@ $<
 
 %.o: %.cpp
 	$(CXX) -MMD $(PG) $(INCLUDES) $(FINAL_FLAGS) $(CXXFLAGS) -c -o $@ $<
@@ -119,7 +141,7 @@ indent:
 TESTS = $(wildcard tests/*/out/*.json)
 SPACE = $(NULL) $(NULL)
 
-test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test mlt-test mlt-decode-test mlt-output-test
+test: tippecanoe tippecanoe-decode $(addsuffix .check,$(TESTS)) raw-tiles-test parallel-test pbf-test join-test enumerate-test decode-test join-filter-test unit json-tool-test allow-existing-test csv-test layer-json-test pmtiles-test decode-pmtiles-test overzoom-test flatgeobuf-test $(MLT_TESTS)
 	./unit
 
 suffixes = json json.gz

--- a/README.md
+++ b/README.md
@@ -553,9 +553,9 @@ the same layer, enclose them in an `all` expression so they will all be evaluate
  * `-pf` or `--no-feature-limit`: Don't limit tiles to 200,000 features
  * `-pk` or `--no-tile-size-limit`: Don't limit tiles to 500K bytes
  * `-pC` or `--no-tile-compression`: Don't compress the vector tile data. If you are getting "Unimplemented type 3" error messages from a renderer, it is probably because it expects uncompressed tiles using this option rather than the normal gzip-compressed tiles.
- * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)). MLT is a columnar format that typically produces smaller tiles than MVT.
- * `--pretessellate`: When using `--output-format=mlt`, pre-triangulate polygon geometries for faster rendering. Only applies to layers where all features are polygons.
- * `--no-mlt-feature-sort`: When using `--output-format=mlt`, disable within-tile spatial sorting of features by Hilbert curve index. Sorting is on by default and improves compression.
+ * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)).
+ * `--pretessellate`: When using `--output-format=mlt`, pre-triangulate polygon geometries. Only applies to layers where all features are polygons.
+ * `--no-mlt-feature-sort`: When using `--output-format=mlt`, disable within-tile spatial sorting of features by Hilbert curve index. Sorting is on by default.
  * `-pg` or `--no-tile-stats`: Don't generate the `tilestats` row in the tileset metadata. Uploads without [tilestats](https://github.com/mapbox/mapbox-geostats) will take longer to process.
  * `--tile-stats-attributes-limit=`*count*: Include `tilestats` information about at most *count* attributes instead of the default 1000.
  * `--tile-stats-sample-values-limit=`*count*: Calculate `tilestats` attribute statistics based on *count* values instead of the default 1000.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ $ make -j
 $ make install
 ```
 
+The submodule is the [MapLibre Tile](https://github.com/maplibre/maplibre-tile-spec)
+implementation, which is built with `cmake`. If you don't need MapLibre Tile support,
+build with `make MLT=0` instead, which needs neither the submodule nor `cmake`. Such a
+build can't read or write MLT, and rejects `--output-format=mlt`, but is otherwise the same.
+Run `make clean` first if you are switching an existing build directory between the two.
+
 See [Development](#development) below for how to upgrade your
 C++ compiler or install prerequisite packages if you get
 compiler errors.

--- a/README.md
+++ b/README.md
@@ -777,8 +777,8 @@ mbtiles output. If they define the same layers or the same tiles, the layers
 or tiles are merged.
 
 Sources may contain either Mapbox Vector Tiles or MapLibre Tiles, in any combination,
-since the encoding is detected from the tile data. The output is always written as
-Mapbox Vector Tiles.
+since the encoding is detected from the tile data. The output is written as Mapbox
+Vector Tiles unless `--output-format=mlt` is specified.
 
 The options are:
 
@@ -829,6 +829,9 @@ The options are:
 
  * `-pk` or `--no-tile-size-limit`: Don't skip tiles larger than 500K.
  * `-pC` or `--no-tile-compression`: Don't compress the vector tile data.
+ * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)). Applies regardless of what the sources are encoded in.
+ * `--pretessellate`: When using `--output-format=mlt`, pre-triangulate polygon geometries. Only applies to layers where all features are polygons.
+ * `--no-mlt-feature-sort`: When using `--output-format=mlt`, disable within-tile spatial sorting of features by Hilbert curve index. Sorting is on by default.
  * `-pg` or `--no-tile-stats`: Don't generate the `tilestats` row in the tileset metadata. Uploads without [tilestats](https://github.com/mapbox/mapbox-geostats) will take longer to process.
  * `--tile-stats-attributes-limit=`*count*: Include `tilestats` information about at most *count* attributes instead of the default 1000.
  * `--tile-stats-sample-values-limit=`*count*: Calculate `tilestats` attribute statistics based on *count* values instead of the default 1000.
@@ -1015,7 +1018,8 @@ reads tile `inz/inx/iny` of `in.mvt.gz`, tile `in2z/in2x/in2y` of `in2.mvt.gz`, 
 and produces tile `outz/outx/outy` of `out.mvt.gz` from them.
 
 The input tiles may be either Mapbox Vector Tiles or MapLibre Tiles, since the encoding
-is detected from the tile data. The output tile is always a Mapbox Vector Tile.
+is detected from the tile data. The output tile is a Mapbox Vector Tile unless
+`--output-format=mlt` is specified.
 
 ### Options
 
@@ -1026,3 +1030,6 @@ is detected from the tile data. The output tile is always a Mapbox Vector Tile.
  * `-m`: If a tile was created with the `--retain-points-multiplier` option, thin the tile back down to its normal feature count during overzooming. The first feature from each cluster will be retained, unless `-j` is used to specify a filter, in which case the first matching filter from each cluster will be retained instead.
  * `--preserve-input-order`: Restore a set of filtered features to its original input order
  * `--accumulate-attribute`: Behaves as in `tippecanoe` to sum attributes from the features of a multiplier cluster that are not included in the final output. The attributes from features that are filtered away with `-j` are *not* accumulated onto the output feature.
+ * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)). Applies regardless of what the input tiles are encoded in.
+ * `--pretessellate`: When using `--output-format=mlt`, pre-triangulate polygon geometries. Only applies to layers where all features are polygons.
+ * `--no-mlt-feature-sort`: When using `--output-format=mlt`, disable within-tile spatial sorting of features by Hilbert curve index. Sorting is on by default.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ brew install tippecanoe
 On Ubuntu it will usually be easiest to build from the source repository:
 
 ```sh
-$ git clone https://github.com/felt/tippecanoe.git
+$ git clone --recurse-submodules https://github.com/felt/tippecanoe.git
 $ cd tippecanoe
 $ make -j
 $ make install

--- a/README.md
+++ b/README.md
@@ -552,7 +552,10 @@ the same layer, enclose them in an `all` expression so they will all be evaluate
  * `--limit-tile-feature-count-at-maximum-zoom=`_features_: Abruptly limit each tile at the maximum zoom level to the specified number of _features_, after ordering them if specified.
  * `-pf` or `--no-feature-limit`: Don't limit tiles to 200,000 features
  * `-pk` or `--no-tile-size-limit`: Don't limit tiles to 500K bytes
- * `-pC` or `--no-tile-compression`: Don't compress the PBF vector tile data. If you are getting "Unimplemented type 3" error messages from a renderer, it is probably because it expects uncompressed tiles using this option rather than the normal gzip-compressed tiles.
+ * `-pC` or `--no-tile-compression`: Don't compress the vector tile data. If you are getting "Unimplemented type 3" error messages from a renderer, it is probably because it expects uncompressed tiles using this option rather than the normal gzip-compressed tiles.
+ * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)). MLT is a columnar format that typically produces smaller tiles than MVT.
+ * `--pretessellate`: When using `--output-format=mlt`, pre-triangulate polygon geometries for faster rendering. Only applies to layers where all features are polygons.
+ * `--no-mlt-feature-sort`: When using `--output-format=mlt`, disable within-tile spatial sorting of features by Hilbert curve index. Sorting is on by default and improves compression.
  * `-pg` or `--no-tile-stats`: Don't generate the `tilestats` row in the tileset metadata. Uploads without [tilestats](https://github.com/mapbox/mapbox-geostats) will take longer to process.
  * `--tile-stats-attributes-limit=`*count*: Include `tilestats` information about at most *count* attributes instead of the default 1000.
  * `--tile-stats-sample-values-limit=`*count*: Calculate `tilestats` attribute statistics based on *count* values instead of the default 1000.
@@ -821,7 +824,7 @@ The options are:
 ### Setting or disabling tile size limits
 
  * `-pk` or `--no-tile-size-limit`: Don't skip tiles larger than 500K.
- * `-pC` or `--no-tile-compression`: Don't compress the PBF vector tile data.
+ * `-pC` or `--no-tile-compression`: Don't compress the vector tile data.
  * `-pg` or `--no-tile-stats`: Don't generate the `tilestats` row in the tileset metadata. Uploads without [tilestats](https://github.com/mapbox/mapbox-geostats) will take longer to process.
  * `--tile-stats-attributes-limit=`*count*: Include `tilestats` information about at most *count* attributes instead of the default 1000.
  * `--tile-stats-sample-values-limit=`*count*: Calculate `tilestats` attribute statistics based on *count* values instead of the default 1000.

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ the same layer, enclose them in an `all` expression so they will all be evaluate
  * `-pf` or `--no-feature-limit`: Don't limit tiles to 200,000 features
  * `-pk` or `--no-tile-size-limit`: Don't limit tiles to 500K bytes
  * `-pC` or `--no-tile-compression`: Don't compress the vector tile data. If you are getting "Unimplemented type 3" error messages from a renderer, it is probably because it expects uncompressed tiles using this option rather than the normal gzip-compressed tiles.
- * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)).
+ * `--output-format=`*format*: Set the tile encoding format. Supported values: `mvt` (default, Mapbox Vector Tiles) or `mlt` ([MapLibre Tiles](https://github.com/maplibre/maplibre-tile-spec)). MLT tilesets can be read back by `tippecanoe-decode`, `tile-join`, and `tippecanoe-overzoom`. Because MLT attribute columns have a single type for the whole layer, while MVT attribute values are individually typed, an attribute whose values are a mix of numbers and strings (or of booleans and numbers) is encoded as strings.
  * `--pretessellate`: When using `--output-format=mlt`, pre-triangulate polygon geometries. Only applies to layers where all features are polygons.
  * `--no-mlt-feature-sort`: When using `--output-format=mlt`, disable within-tile spatial sorting of features by Hilbert curve index. Sorting is on by default.
  * `-pg` or `--no-tile-stats`: Don't generate the `tilestats` row in the tileset metadata. Uploads without [tilestats](https://github.com/mapbox/mapbox-geostats) will take longer to process.
@@ -776,6 +776,10 @@ all the sources are read and their combined contents are written to the new
 mbtiles output. If they define the same layers or the same tiles, the layers
 or tiles are merged.
 
+Sources may contain either Mapbox Vector Tiles or MapLibre Tiles, in any combination,
+since the encoding is detected from the tile data. The output is always written as
+Mapbox Vector Tiles.
+
 The options are:
 
 ### Output tileset
@@ -906,6 +910,10 @@ or on an individual tile:
     tippecanoe-decode file.mbtiles zoom x y
     tippecanoe-decode file.vector.pbf zoom x y
 
+Tiles can be either Mapbox Vector Tiles or MapLibre Tiles; the encoding is detected
+from the tile data, so no option is needed to decode a tileset that was written with
+`--output-format=mlt`.
+
 Unless you use `-c`, the output is a set of nested FeatureCollections identifying each
 tile and layer separately. Note that the same features generally appear at all zooms,
 so the output for the file will have many copies of the same features at different
@@ -1005,6 +1013,9 @@ reads tile `inz/inx/iny` of `in.mvt.gz` and produces tile `outz/outx/outy` of `o
 
 reads tile `inz/inx/iny` of `in.mvt.gz`, tile `in2z/in2x/in2y` of `in2.mvt.gz`, and tile `in3z/in3x/in3y` of `in3.mvt.gz`,
 and produces tile `outz/outx/outy` of `out.mvt.gz` from them.
+
+The input tiles may be either Mapbox Vector Tiles or MapLibre Tiles, since the encoding
+is detected from the tile data. The output tile is always a Mapbox Vector Tile.
 
 ### Options
 

--- a/clip.cpp
+++ b/clip.cpp
@@ -10,6 +10,7 @@
 #include "errors.hpp"
 #include "compression.hpp"
 #include "mvt.hpp"
+#include "mlt.hpp"
 #include "evaluator.hpp"
 #include "serial.hpp"
 #include "attribute.hpp"
@@ -1228,7 +1229,8 @@ std::string overzoom(std::vector<input_tile> const &tiles, int nz, int nx, int n
 		     std::vector<mvt_layer> const &unused2, std::string const &unused3,
 		     std::string const &unused, size_t feature_limit,
 		     std::vector<clipbbox> const &unused4,
-		     bool deduplicate_by_id) {
+		     bool deduplicate_by_id,
+		     int tile_format) {
 	std::vector<source_tile> decoded;
 
 	for (auto const &t : tiles) {
@@ -1254,7 +1256,7 @@ std::string overzoom(std::vector<input_tile> const &tiles, int nz, int nx, int n
 		decoded.push_back(out);
 	}
 
-	return overzoom(decoded, nz, nx, ny, detail_or_unspecified, buffer, keep, exclude, exclude_prefix, do_compress, next_overzoomed_tiles, demultiply, filter, preserve_input_order, attribute_accum, unidecode_data, simplification, tiny_polygon_size, unused2, unused3, unused, feature_limit, unused4, deduplicate_by_id);
+	return overzoom(decoded, nz, nx, ny, detail_or_unspecified, buffer, keep, exclude, exclude_prefix, do_compress, next_overzoomed_tiles, demultiply, filter, preserve_input_order, attribute_accum, unidecode_data, simplification, tiny_polygon_size, unused2, unused3, unused, feature_limit, unused4, deduplicate_by_id, tile_format);
 }
 
 // like a minimal serial_feature, but with mvt_feature-style attributes
@@ -1464,7 +1466,8 @@ std::string overzoom(std::vector<source_tile> const &tiles, int nz, int nx, int 
 		     std::vector<mvt_layer> const &unused2, std::string const &unused3,
 		     std::string const &unused, size_t feature_limit,
 		     std::vector<clipbbox> const &unused4,
-		     bool deduplicate_by_id) {
+		     bool deduplicate_by_id,
+		     int tile_format) {
 	mvt_tile outtile;
 	key_pool key_pool;
 
@@ -1737,7 +1740,7 @@ std::string overzoom(std::vector<source_tile> const &tiles, int nz, int nx, int 
 	}
 
 	if (outtile.layers.size() > 0) {
-		std::string pbf = outtile.encode();
+		std::string pbf = encode_tile(outtile, tile_format);
 
 		std::string compressed;
 		if (do_compress) {

--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -76,12 +76,18 @@ static bool numeric(const char *s) {
 	return true;
 }
 
-static bool pbfname(const char *s) {
+// If this is the name of a tile within a tile directory, returns the
+// extension that it uses, or NULL if it isn't a tile at all.
+static const char *tile_extension(const char *s) {
 	while (*s >= '0' && *s <= '9') {
 		s++;
 	}
 
-	return strcmp(s, ".pbf") == 0 || strcmp(s, ".mvt") == 0 || strcmp(s, ".mlt") == 0;
+	if (strcmp(s, ".pbf") == 0 || strcmp(s, ".mvt") == 0 || strcmp(s, ".mlt") == 0) {
+		return s;
+	}
+
+	return NULL;
 }
 
 void check_dir(const char *dir, char **argv, bool force, bool forcetable) {
@@ -154,12 +160,11 @@ std::vector<zxy> enumerate_dirtiles(const char *fname, int minzoom, int maxzoom)
 
 						struct dirent *dp3;
 						while ((dp3 = readdir(d3)) != NULL) {
-							if (pbfname(dp3->d_name)) {
+							const char *ext = tile_extension(dp3->d_name);
+							if (ext != NULL) {
 								int ty = atoi(dp3->d_name);
 								zxy tile(tz, tx, ty);
-								if (strstr(dp3->d_name, ".mvt") != NULL) {
-									tile.extension = ".mvt";
-								}
+								tile.extension = ext;
 
 								tiles.push_back(tile);
 							}
@@ -207,7 +212,7 @@ void dir_erase_zoom(const char *fname, int zoom) {
 
 						struct dirent *dp3;
 						while ((dp3 = readdir(d3)) != NULL) {
-							if (pbfname(dp3->d_name)) {
+							if (tile_extension(dp3->d_name) != NULL) {
 								std::string y = x + "/" + dp3->d_name;
 								if (unlink(y.c_str()) != 0) {
 									perror(y.c_str());

--- a/dirtiles.cpp
+++ b/dirtiles.cpp
@@ -25,7 +25,7 @@ std::string dir_read_tile(std::string base, struct zxy tile) {
 	return (contents.str());
 }
 
-void dir_write_tile(const char *outdir, int z, int tx, int ty, std::string const &pbf) {
+void dir_write_tile(const char *outdir, int z, int tx, int ty, std::string const &pbf, const char *ext) {
 	// Don't check mkdir error returns, since most of these calls to
 	// mkdir will be creating directories that already exist.
 	mkdir(outdir, S_IRWXU | S_IRWXG | S_IRWXO);
@@ -39,7 +39,7 @@ void dir_write_tile(const char *outdir, int z, int tx, int ty, std::string const
 	newdir = newdir + "/" + std::to_string(tx);
 	mkdir(newdir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
 
-	newdir = newdir + "/" + std::to_string(ty) + ".pbf";
+	newdir = newdir + "/" + std::to_string(ty) + ext;
 
 	struct stat st;
 	if (stat(newdir.c_str(), &st) == 0) {
@@ -81,7 +81,7 @@ static bool pbfname(const char *s) {
 		s++;
 	}
 
-	return strcmp(s, ".pbf") == 0 || strcmp(s, ".mvt") == 0;
+	return strcmp(s, ".pbf") == 0 || strcmp(s, ".mvt") == 0 || strcmp(s, ".mlt") == 0;
 }
 
 void check_dir(const char *dir, char **argv, bool force, bool forcetable) {

--- a/dirtiles.hpp
+++ b/dirtiles.hpp
@@ -6,7 +6,7 @@
 #ifndef DIRTILES_HPP
 #define DIRTILES_HPP
 
-void dir_write_tile(const char *outdir, int z, int tx, int ty, std::string const &pbf);
+void dir_write_tile(const char *outdir, int z, int tx, int ty, std::string const &pbf, const char *ext = ".pbf");
 void dir_erase_zoom(const char *outdir, int z);
 void dir_write_metadata(const char *outdir, const metadata &m);
 

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -148,7 +148,8 @@ std::string overzoom(std::vector<source_tile> const &tiles, int nz, int nx, int 
 		     std::vector<mvt_layer> const &bins, std::string const &bin_by_id_list,
 		     std::string const &accumulate_numeric, size_t feature_limit,
 		     std::vector<clipbbox> const &clipbboxes,
-		     bool deduplicate_by_id);
+		     bool deduplicate_by_id,
+		     int tile_format = OUTPUT_MVT);
 
 std::string overzoom(std::vector<input_tile> const &tiles, int nz, int nx, int ny,
 		     int detail, int buffer,
@@ -164,7 +165,8 @@ std::string overzoom(std::vector<input_tile> const &tiles, int nz, int nx, int n
 		     std::vector<mvt_layer> const &bins, std::string const &bin_by_id_list,
 		     std::string const &accumulate_numeric, size_t feature_limit,
 		     std::vector<clipbbox> const &clipbboxes,
-		     bool deduplicate_by_id);
+		     bool deduplicate_by_id,
+		     int tile_format = OUTPUT_MVT);
 
 draw center_of_mass_mp(const drawvec &dv);
 

--- a/main.cpp
+++ b/main.cpp
@@ -50,6 +50,7 @@
 #include "projection.hpp"
 #include "memfile.hpp"
 #include "main.hpp"
+#include "mlt.hpp"
 #include "geojson.hpp"
 #include "geobuf.hpp"
 #include "flatgeobuf.hpp"
@@ -104,9 +105,6 @@ bool drop_by_attribute_descending = false;
 std::vector<order_field> order_by;
 bool order_reverse;
 bool order_by_size = false;
-int output_format = OUTPUT_MVT;
-bool mlt_sort_features = true;
-bool mlt_pretessellate = false;
 
 int prevent[256];
 int additional[256];
@@ -2827,7 +2825,7 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		ai->second.maxzoom = maxzoom;
 	}
 
-	const char *tile_format = (output_format == OUTPUT_MLT) ? "mlt" : "pbf";
+	const char *tile_format = tile_format_name(output_format);
 	metadata m = make_metadata(fname, minzoom, maxzoom, minlat, minlon, maxlat, maxlon, minlat2, minlon2, maxlat2, maxlon2, midlat, midlon, attribution, merged_lm, tile_format, description, !prevent[P_TILE_STATS], attribute_descriptions, "tippecanoe", commandline, strategies, basezoom, droprate, retain_points_multiplier);
 	if (outdb != NULL) {
 		mbtiles_write_metadata(outdb, m, forcetable);
@@ -3335,14 +3333,7 @@ int main(int argc, char **argv) {
 			} else if (strcmp(opt, "maximum-string-attribute-length") == 0) {
 				maximum_string_attribute_length = atoll_require(optarg, "Maximum string attribute length");
 			} else if (strcmp(opt, "output-format") == 0) {
-				if (strcmp(optarg, "mvt") == 0 || strcmp(optarg, "pbf") == 0) {
-					output_format = OUTPUT_MVT;
-				} else if (strcmp(optarg, "mlt") == 0) {
-					output_format = OUTPUT_MLT;
-				} else {
-					fprintf(stderr, "%s: --output-format must be 'mvt' or 'mlt'\n", argv[0]);
-					exit(EXIT_ARGS);
-				}
+				set_output_format(argv, optarg);
 			} else if (strcmp(opt, "pretessellate") == 0) {
 				mlt_pretessellate = true;
 			} else if (strcmp(opt, "no-mlt-feature-sort") == 0) {

--- a/main.cpp
+++ b/main.cpp
@@ -104,6 +104,9 @@ bool drop_by_attribute_descending = false;
 std::vector<order_field> order_by;
 bool order_reverse;
 bool order_by_size = false;
+int output_format = OUTPUT_MVT;
+bool mlt_sort_features = true;
+bool mlt_pretessellate = false;
 
 int prevent[256];
 int additional[256];
@@ -2824,7 +2827,8 @@ std::pair<int, metadata> read_input(std::vector<source> &sources, char *fname, i
 		ai->second.maxzoom = maxzoom;
 	}
 
-	metadata m = make_metadata(fname, minzoom, maxzoom, minlat, minlon, maxlat, maxlon, minlat2, minlon2, maxlat2, maxlon2, midlat, midlon, attribution, merged_lm, true, description, !prevent[P_TILE_STATS], attribute_descriptions, "tippecanoe", commandline, strategies, basezoom, droprate, retain_points_multiplier);
+	const char *tile_format = (output_format == OUTPUT_MLT) ? "mlt" : "pbf";
+	metadata m = make_metadata(fname, minzoom, maxzoom, minlat, minlon, maxlat, maxlon, minlat2, minlon2, maxlat2, maxlon2, midlat, midlon, attribution, merged_lm, tile_format, description, !prevent[P_TILE_STATS], attribute_descriptions, "tippecanoe", commandline, strategies, basezoom, droprate, retain_points_multiplier);
 	if (outdb != NULL) {
 		mbtiles_write_metadata(outdb, m, forcetable);
 	} else {
@@ -3160,6 +3164,9 @@ int main(int argc, char **argv) {
 		{"no-feature-limit", no_argument, &prevent[P_FEATURE_LIMIT], 1},
 		{"no-tile-size-limit", no_argument, &prevent[P_KILOBYTE_LIMIT], 1},
 		{"no-tile-compression", no_argument, &prevent[P_TILE_COMPRESSION], 1},
+		{"output-format", required_argument, 0, '~'},
+		{"pretessellate", no_argument, 0, '~'},
+		{"no-mlt-feature-sort", no_argument, 0, '~'},
 		{"no-tile-stats", no_argument, &prevent[P_TILE_STATS], 1},
 		{"tile-stats-attributes-limit", required_argument, 0, '~'},
 		{"tile-stats-sample-values-limit", required_argument, 0, '~'},
@@ -3327,6 +3334,19 @@ int main(int argc, char **argv) {
 				unidecode_data = read_unidecode(optarg);
 			} else if (strcmp(opt, "maximum-string-attribute-length") == 0) {
 				maximum_string_attribute_length = atoll_require(optarg, "Maximum string attribute length");
+			} else if (strcmp(opt, "output-format") == 0) {
+				if (strcmp(optarg, "mvt") == 0 || strcmp(optarg, "pbf") == 0) {
+					output_format = OUTPUT_MVT;
+				} else if (strcmp(optarg, "mlt") == 0) {
+					output_format = OUTPUT_MLT;
+				} else {
+					fprintf(stderr, "%s: --output-format must be 'mvt' or 'mlt'\n", argv[0]);
+					exit(EXIT_ARGS);
+				}
+			} else if (strcmp(opt, "pretessellate") == 0) {
+				mlt_pretessellate = true;
+			} else if (strcmp(opt, "no-mlt-feature-sort") == 0) {
+				mlt_sort_features = false;
 			} else {
 				fprintf(stderr, "%s: Unrecognized option --%s\n", argv[0], opt);
 				exit(EXIT_ARGS);

--- a/main.hpp
+++ b/main.hpp
@@ -76,4 +76,11 @@ bool progress_time();
 
 #define MAX_ZOOM 24
 
+#define OUTPUT_MVT 0
+#define OUTPUT_MLT 1
+
+extern int output_format;
+extern bool mlt_sort_features;
+extern bool mlt_pretessellate;
+
 #endif

--- a/main.hpp
+++ b/main.hpp
@@ -76,11 +76,4 @@ bool progress_time();
 
 #define MAX_ZOOM 24
 
-#define OUTPUT_MVT 0
-#define OUTPUT_MLT 1
-
-extern int output_format;
-extern bool mlt_sort_features;
-extern bool mlt_pretessellate;
-
 #endif

--- a/mbtiles.cpp
+++ b/mbtiles.cpp
@@ -665,14 +665,14 @@ std::string version_str() {
 	return s;
 }
 
-metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double minlat2, double minlon2, double maxlat2, double maxlon2, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies, int basezoom, double droprate, int retain_points_multiplier) {
+metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double minlat2, double minlon2, double maxlat2, double maxlon2, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, const char *tile_format, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies, int basezoom, double droprate, int retain_points_multiplier) {
 	metadata m;
 
 	m.name = fname;
 	m.description = description != NULL ? description : fname;
 	m.version = 2;
 	m.type = "overlay";
-	m.format = vector ? "pbf" : "png";
+	m.format = tile_format;
 
 	m.minzoom = minzoom;
 	m.maxzoom = maxzoom;
@@ -711,7 +711,8 @@ metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minla
 				   std::string("}");
 	}
 
-	if (vector) {
+	bool is_vector_format = (strcmp(tile_format, "pbf") == 0 || strcmp(tile_format, "mlt") == 0);
+	if (is_vector_format) {
 		{
 			json_writer state(&m.vector_layers_json);
 

--- a/mbtiles.hpp
+++ b/mbtiles.hpp
@@ -68,7 +68,7 @@ sqlite3 *mbtiles_open(char *dbname, char **argv, int forcetable);
 void mbtiles_write_tile(sqlite3 *outdb, int z, int tx, int ty, const char *data, int size);
 void mbtiles_erase_zoom(sqlite3 *outdb, int z);
 
-metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double minlat2, double minlon2, double maxlat2, double maxlon2, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, bool vector, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies, int basezoom, double droprate, int retain_points_multiplier);
+metadata make_metadata(const char *fname, int minzoom, int maxzoom, double minlat, double minlon, double maxlat, double maxlon, double minlat2, double minlon2, double maxlat2, double maxlon2, double midlat, double midlon, const char *attribution, std::map<std::string, layermap_entry> const &layermap, const char *tile_format, const char *description, bool do_tilestats, std::map<std::string, std::string> const &attribute_descriptions, std::string const &program, std::string const &commandline, std::vector<strategy> const &strategies, int basezoom, double droprate, int retain_points_multiplier);
 void mbtiles_write_metadata(sqlite3 *db, const metadata &m, bool forcetable);
 
 void mbtiles_close(sqlite3 *outdb, const char *pgm);

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -1,8 +1,6 @@
 #include "mlt.hpp"
 #include "errors.hpp"
 
-#include <mlt/encoder.hpp>
-
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -12,7 +10,11 @@
 #include <string>
 #include <vector>
 
+#ifndef NO_MLT
+#include <mlt/encoder.hpp>
+
 using Vertex = mlt::Encoder::Vertex;
+#endif
 
 int output_format = OUTPUT_MVT;
 bool mlt_sort_features = true;
@@ -22,7 +24,12 @@ void set_output_format(char **argv, const char *format) {
 	if (strcmp(format, "mvt") == 0 || strcmp(format, "pbf") == 0) {
 		output_format = OUTPUT_MVT;
 	} else if (strcmp(format, "mlt") == 0) {
+#ifdef NO_MLT
+		fprintf(stderr, "%s: this build was compiled without MapLibre Tile support\n", argv[0]);
+		exit(EXIT_ARGS);
+#else
 		output_format = OUTPUT_MLT;
+#endif
 	} else {
 		fprintf(stderr, "%s: --output-format must be 'mvt' or 'mlt'\n", argv[0]);
 		exit(EXIT_ARGS);
@@ -38,12 +45,18 @@ const char *tile_format_extension(int format) {
 }
 
 std::string encode_tile(mvt_tile &tile, int format) {
+#ifndef NO_MLT
 	if (format == OUTPUT_MLT) {
 		return encode_as_mlt(tile, mlt_sort_features, mlt_pretessellate);
-	} else {
-		return tile.encode();
 	}
+#else
+	(void) format;
+#endif
+
+	return tile.encode();
 }
+
+#ifndef NO_MLT
 
 // An MLT property column has a single type for the whole layer, while MVT
 // values each carry their own type, so a type that can hold every value of
@@ -327,3 +340,5 @@ std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretess
 	auto bytes = encoder.encode(layers, config);
 	return std::string(reinterpret_cast<const char *>(bytes.data()), bytes.size());
 }
+
+#endif

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -1,4 +1,5 @@
 #include "mlt.hpp"
+#include "jsonpull/jsonpull.h"
 
 #include <mlt/encoder.hpp>
 
@@ -8,6 +9,68 @@
 #include <vector>
 
 using Vertex = mlt::Encoder::Vertex;
+
+// Try to parse a JSON object string into MLT STRUCT (flat string children only)
+static bool try_parse_json_object(const std::string &s, mlt::Encoder::StructValue &out) {
+	if (s.empty() || s[0] != '{') {
+		return false;
+	}
+
+	json_pull *jp = json_begin_string(s.c_str());
+	json_object *obj = json_read_tree(jp);
+
+	if (obj == nullptr || obj->type != JSON_HASH) {
+		json_free(obj);
+		json_end(jp);
+		return false;
+	}
+
+	for (size_t i = 0; i < obj->value.object.length; i++) {
+		json_object *key = obj->value.object.keys[i];
+		json_object *val = obj->value.object.values[i];
+
+		if (key->type != JSON_STRING) continue;
+
+		std::string child_key = key->value.string.string;
+		std::string child_val;
+
+		switch (val->type) {
+		case JSON_STRING:
+			child_val = val->value.string.string;
+			break;
+		case JSON_NUMBER:
+			if (val->value.number.large_unsigned != 0) {
+				child_val = std::to_string(val->value.number.large_unsigned);
+			} else if (val->value.number.large_signed != 0) {
+				child_val = std::to_string(val->value.number.large_signed);
+			} else {
+				child_val = std::to_string(val->value.number.number);
+			}
+			break;
+		case JSON_TRUE:
+			child_val = "true";
+			break;
+		case JSON_FALSE:
+			child_val = "false";
+			break;
+		case JSON_NULL:
+			child_val = "null";
+			break;
+		default:
+			// Nested object/array - stringify back
+			char *nested = json_stringify(val);
+			child_val = nested;
+			free(nested);
+			break;
+		}
+
+		out[child_key] = child_val;
+	}
+
+	json_free(obj);
+	json_end(jp);
+	return true;
+}
 
 static mlt::Encoder::PropertyValue convert_value(const mvt_value &val) {
 	switch (val.type) {
@@ -32,8 +95,14 @@ static mlt::Encoder::PropertyValue convert_value(const mvt_value &val) {
 		return val.numeric_value.float_value;
 	case mvt_double:
 		return val.numeric_value.double_value;
-	case mvt_string:
-		return val.get_string_value();
+	case mvt_string: {
+		std::string s = val.get_string_value();
+		mlt::Encoder::StructValue struct_val;
+		if (try_parse_json_object(s, struct_val)) {
+			return struct_val;
+		}
+		return s;
+	}
 	default:
 		return std::string{};
 	}

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -11,8 +11,7 @@
 
 using Vertex = mlt::Encoder::Vertex;
 
-// Try to parse a JSON object string into MLT STRUCT (flat string children only)
-static bool try_parse_json_object(const std::string &s, mlt::Encoder::StructValue &out) {
+static bool parse_json_object_property(const std::string &s, mlt::Encoder::StructValue &out) {
 	if (s.empty() || s[0] != '{') {
 		return false;
 	}
@@ -60,7 +59,6 @@ static bool try_parse_json_object(const std::string &s, mlt::Encoder::StructValu
 			child_val = "null";
 			break;
 		default:
-			// Nested object/array - stringify back
 			char *nested = json_stringify(val);
 			child_val = nested;
 			free(nested);
@@ -101,7 +99,7 @@ static mlt::Encoder::PropertyValue convert_value(const mvt_value &val) {
 	case mvt_string: {
 		std::string s = val.get_string_value();
 		mlt::Encoder::StructValue struct_val;
-		if (try_parse_json_object(s, struct_val)) {
+		if (parse_json_object_property(s, struct_val)) {
 			return struct_val;
 		}
 		return s;
@@ -111,8 +109,6 @@ static mlt::Encoder::PropertyValue convert_value(const mvt_value &val) {
 	}
 }
 
-// Split MVT command stream into coordinate rings (sequences between moveto commands).
-// Each ring is a vector of vertices. For polygons, closepath is implicit (MLT strips closing points).
 static std::vector<std::vector<Vertex>> extract_rings(const mvt_feature &feature) {
 	std::vector<std::vector<Vertex>> rings;
 
@@ -124,7 +120,6 @@ static std::vector<std::vector<Vertex>> extract_rings(const mvt_feature &feature
 		} else if (g.op == mvt_lineto) {
 			rings.back().push_back({static_cast<int32_t>(g.x), static_cast<int32_t>(g.y)});
 		}
-		// mvt_closepath: polygon ring close — MLT stores without closing point
 	}
 	return rings;
 }
@@ -160,12 +155,9 @@ static mlt::Encoder::Geometry convert_geometry(const mvt_feature &feature) {
 		break;
 
 	case mvt_polygon: {
-		// Outer rings are clockwise (positive area), holes are counter-clockwise.
-		// Group into polygons: each outer ring starts a new polygon.
 		std::vector<std::vector<std::vector<Vertex>>> polygons;
 
 		for (auto &ring : rings) {
-			// Signed area to detect winding: positive = clockwise = outer ring (in MVT screen coords)
 			long long area2 = 0;
 			for (size_t i = 0; i < ring.size(); i++) {
 				size_t j = (i + 1) % ring.size();
@@ -173,7 +165,6 @@ static mlt::Encoder::Geometry convert_geometry(const mvt_feature &feature) {
 			}
 
 			if (area2 >= 0) {
-				// Outer ring — start new polygon
 				polygons.emplace_back();
 			}
 			if (!polygons.empty()) {

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,9 @@ static bool try_parse_json_object(const std::string &s, mlt::Encoder::StructValu
 		json_object *key = obj->value.object.keys[i];
 		json_object *val = obj->value.object.values[i];
 
-		if (key->type != JSON_STRING) continue;
+		if (key->type != JSON_STRING) {
+			continue;
+		}
 
 		std::string child_key = key->value.string.string;
 		std::string child_val;
@@ -211,7 +214,11 @@ static mlt::Encoder::Layer convert_layer(const mvt_layer &layer) {
 
 	for (const auto &feature : layer.features) {
 		mlt::Encoder::Feature f;
-		f.id = feature.id;
+		if (feature.has_id) {
+			f.id = feature.id;
+		} else {
+			f.id = std::nullopt;
+		}
 		f.geometry = convert_geometry(feature);
 
 		for (size_t t = 0; t + 1 < feature.tags.size(); t += 2) {
@@ -245,7 +252,9 @@ std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretess
 				break;
 			}
 		}
-		if (any_has_id) break;
+		if (any_has_id) {
+			break;
+		}
 	}
 	config.includeIds = any_has_id;
 

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -1,8 +1,8 @@
 #include "mlt.hpp"
-#include "jsonpull/jsonpull.h"
 
 #include <mlt/encoder.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <optional>
@@ -11,101 +11,117 @@
 
 using Vertex = mlt::Encoder::Vertex;
 
-static bool parse_json_object_property(const std::string &s, mlt::Encoder::StructValue &out) {
-	if (s.empty() || s[0] != '{') {
-		return false;
-	}
+// An MLT property column has a single type for the whole layer, while MVT
+// values each carry their own type, so a type that can hold every value of
+// an attribute has to be chosen before the layer can be converted.
 
-	json_pull *jp = json_begin_string(s.c_str());
-	json_object *obj = json_read_tree(jp);
+enum mlt_column_type {
+	MLT_COLUMN_BOOL,
+	MLT_COLUMN_INT32,
+	MLT_COLUMN_INT64,
+	MLT_COLUMN_UINT32,
+	MLT_COLUMN_UINT64,
+	MLT_COLUMN_DOUBLE,
+	MLT_COLUMN_STRING,
+};
 
-	if (obj == nullptr || obj->type != JSON_HASH) {
-		json_free(obj);
-		json_end(jp);
-		return false;
-	}
+struct column_summary {
+	bool has_bool = false;
+	bool has_string = false;
+	bool has_floating = false;
+	bool has_signed = false;
+	bool has_unsigned = false;
+	long long min_signed = 0;
+	long long max_signed = 0;
+	unsigned long long max_unsigned = 0;
 
-	for (size_t i = 0; i < obj->value.object.length; i++) {
-		json_object *key = obj->value.object.keys[i];
-		json_object *val = obj->value.object.values[i];
-
-		if (key->type != JSON_STRING) {
-			continue;
-		}
-
-		std::string child_key = key->value.string.string;
-		std::string child_val;
-
-		switch (val->type) {
-		case JSON_STRING:
-			child_val = val->value.string.string;
+	void add(const mvt_value &val) {
+		switch (val.type) {
+		case mvt_bool:
+			has_bool = true;
 			break;
-		case JSON_NUMBER:
-			if (val->value.number.large_unsigned != 0) {
-				child_val = std::to_string(val->value.number.large_unsigned);
-			} else if (val->value.number.large_signed != 0) {
-				child_val = std::to_string(val->value.number.large_signed);
+
+		case mvt_float:
+		case mvt_double:
+			has_floating = true;
+			break;
+
+		case mvt_int:
+		case mvt_sint: {
+			long long v = (val.type == mvt_int) ? val.numeric_value.int_value : val.numeric_value.sint_value;
+			if (!has_signed) {
+				min_signed = max_signed = v;
+				has_signed = true;
 			} else {
-				child_val = std::to_string(val->value.number.number);
+				min_signed = std::min(min_signed, v);
+				max_signed = std::max(max_signed, v);
 			}
 			break;
-		case JSON_TRUE:
-			child_val = "true";
+		}
+
+		case mvt_uint:
+			has_unsigned = true;
+			max_unsigned = std::max(max_unsigned, val.numeric_value.uint_value);
 			break;
-		case JSON_FALSE:
-			child_val = "false";
-			break;
-		case JSON_NULL:
-			child_val = "null";
-			break;
+
 		default:
-			char *nested = json_stringify(val);
-			child_val = nested;
-			free(nested);
+			has_string = true;
 			break;
 		}
-
-		out[child_key] = child_val;
 	}
 
-	json_free(obj);
-	json_end(jp);
-	return true;
-}
+	mlt_column_type resolve() const {
+		if (has_string) {
+			return MLT_COLUMN_STRING;
+		}
 
-static mlt::Encoder::PropertyValue convert_value(const mvt_value &val) {
-	switch (val.type) {
-	case mvt_bool:
+		bool has_number = has_floating || has_signed || has_unsigned;
+		if (has_bool) {
+			// A column of booleans and numbers has no common numeric type
+			return has_number ? MLT_COLUMN_STRING : MLT_COLUMN_BOOL;
+		}
+		if (has_floating) {
+			return MLT_COLUMN_DOUBLE;
+		}
+
+		if (has_unsigned && !has_signed) {
+			return max_unsigned <= UINT32_MAX ? MLT_COLUMN_UINT32 : MLT_COLUMN_UINT64;
+		}
+		if (has_signed && !has_unsigned) {
+			return (min_signed >= INT32_MIN && max_signed <= INT32_MAX) ? MLT_COLUMN_INT32 : MLT_COLUMN_INT64;
+		}
+		if (has_signed && has_unsigned) {
+			if (max_unsigned > (unsigned long long) INT64_MAX) {
+				// Too wide for any integer type that can also hold the signed values
+				return MLT_COLUMN_DOUBLE;
+			}
+			return MLT_COLUMN_INT64;
+		}
+
+		return MLT_COLUMN_STRING;
+	}
+};
+
+static mlt::Encoder::PropertyValue convert_value(const mvt_value &val, mlt_column_type type) {
+	switch (type) {
+	case MLT_COLUMN_BOOL:
 		return val.numeric_value.bool_value;
-	case mvt_int:
-		if (val.numeric_value.int_value >= INT32_MIN && val.numeric_value.int_value <= INT32_MAX) {
-			return static_cast<std::int32_t>(val.numeric_value.int_value);
-		}
-		return static_cast<std::int64_t>(val.numeric_value.int_value);
-	case mvt_uint:
-		if (val.numeric_value.uint_value <= UINT32_MAX) {
-			return static_cast<std::uint32_t>(val.numeric_value.uint_value);
-		}
+	case MLT_COLUMN_INT32:
+		return static_cast<std::int32_t>(mvt_value_to_long_long(val));
+	case MLT_COLUMN_INT64:
+		return static_cast<std::int64_t>(mvt_value_to_long_long(val));
+	case MLT_COLUMN_UINT32:
+		return static_cast<std::uint32_t>(val.numeric_value.uint_value);
+	case MLT_COLUMN_UINT64:
 		return static_cast<std::uint64_t>(val.numeric_value.uint_value);
-	case mvt_sint:
-		if (val.numeric_value.sint_value >= INT32_MIN && val.numeric_value.sint_value <= INT32_MAX) {
-			return static_cast<std::int32_t>(val.numeric_value.sint_value);
-		}
-		return static_cast<std::int64_t>(val.numeric_value.sint_value);
-	case mvt_float:
-		return val.numeric_value.float_value;
-	case mvt_double:
-		return val.numeric_value.double_value;
-	case mvt_string: {
-		std::string s = val.get_string_value();
-		mlt::Encoder::StructValue struct_val;
-		if (parse_json_object_property(s, struct_val)) {
-			return struct_val;
-		}
-		return s;
-	}
+	case MLT_COLUMN_DOUBLE:
+		return val.to_double();
+	case MLT_COLUMN_STRING:
 	default:
-		return std::string{};
+		// Nested JSON objects stay JSON text, the way MVT carries them,
+		// because MLT struct columns can only hold strings and are
+		// flattened into their parent column name when decoded.
+		return val.get_string_value();
 	}
 }
 
@@ -203,6 +219,25 @@ static mlt::Encoder::Layer convert_layer(const mvt_layer &layer) {
 	out.name = layer.name;
 	out.extent = static_cast<uint32_t>(layer.extent);
 
+	std::vector<column_summary> summaries(layer.keys.size());
+	for (const auto &feature : layer.features) {
+		for (size_t t = 0; t + 1 < feature.tags.size(); t += 2) {
+			unsigned key_idx = feature.tags[t];
+			unsigned val_idx = feature.tags[t + 1];
+			if (key_idx < layer.keys.size() && val_idx < layer.values.size()) {
+				const auto &val = layer.values[val_idx];
+				if (val.type != mvt_null) {
+					summaries[key_idx].add(val);
+				}
+			}
+		}
+	}
+
+	std::vector<mlt_column_type> types(layer.keys.size(), MLT_COLUMN_STRING);
+	for (size_t i = 0; i < summaries.size(); i++) {
+		types[i] = summaries[i].resolve();
+	}
+
 	for (const auto &feature : layer.features) {
 		mlt::Encoder::Feature f;
 		if (feature.has_id) {
@@ -218,7 +253,7 @@ static mlt::Encoder::Layer convert_layer(const mvt_layer &layer) {
 			if (key_idx < layer.keys.size() && val_idx < layer.values.size()) {
 				const auto &val = layer.values[val_idx];
 				if (val.type != mvt_null) {
-					f.properties[layer.keys[key_idx]] = convert_value(val);
+					f.properties[layer.keys[key_idx]] = convert_value(val, types[key_idx]);
 				}
 			}
 		}

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -1,15 +1,49 @@
 #include "mlt.hpp"
+#include "errors.hpp"
 
 #include <mlt/encoder.hpp>
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <map>
 #include <optional>
 #include <string>
 #include <vector>
 
 using Vertex = mlt::Encoder::Vertex;
+
+int output_format = OUTPUT_MVT;
+bool mlt_sort_features = true;
+bool mlt_pretessellate = false;
+
+void set_output_format(char **argv, const char *format) {
+	if (strcmp(format, "mvt") == 0 || strcmp(format, "pbf") == 0) {
+		output_format = OUTPUT_MVT;
+	} else if (strcmp(format, "mlt") == 0) {
+		output_format = OUTPUT_MLT;
+	} else {
+		fprintf(stderr, "%s: --output-format must be 'mvt' or 'mlt'\n", argv[0]);
+		exit(EXIT_ARGS);
+	}
+}
+
+const char *tile_format_name(int format) {
+	return (format == OUTPUT_MLT) ? "mlt" : "pbf";
+}
+
+const char *tile_format_extension(int format) {
+	return (format == OUTPUT_MLT) ? ".mlt" : ".pbf";
+}
+
+std::string encode_tile(mvt_tile &tile, int format) {
+	if (format == OUTPUT_MLT) {
+		return encode_as_mlt(tile, mlt_sort_features, mlt_pretessellate);
+	} else {
+		return tile.encode();
+	}
+}
 
 // An MLT property column has a single type for the whole layer, while MVT
 // values each carry their own type, so a type that can hold every value of

--- a/mlt.cpp
+++ b/mlt.cpp
@@ -1,0 +1,191 @@
+#include "mlt.hpp"
+
+#include <mlt/encoder.hpp>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+using Vertex = mlt::Encoder::Vertex;
+
+static mlt::Encoder::PropertyValue convert_value(const mvt_value &val) {
+	switch (val.type) {
+	case mvt_bool:
+		return val.numeric_value.bool_value;
+	case mvt_int:
+		if (val.numeric_value.int_value >= INT32_MIN && val.numeric_value.int_value <= INT32_MAX) {
+			return static_cast<std::int32_t>(val.numeric_value.int_value);
+		}
+		return static_cast<std::int64_t>(val.numeric_value.int_value);
+	case mvt_uint:
+		if (val.numeric_value.uint_value <= UINT32_MAX) {
+			return static_cast<std::uint32_t>(val.numeric_value.uint_value);
+		}
+		return static_cast<std::uint64_t>(val.numeric_value.uint_value);
+	case mvt_sint:
+		if (val.numeric_value.sint_value >= INT32_MIN && val.numeric_value.sint_value <= INT32_MAX) {
+			return static_cast<std::int32_t>(val.numeric_value.sint_value);
+		}
+		return static_cast<std::int64_t>(val.numeric_value.sint_value);
+	case mvt_float:
+		return val.numeric_value.float_value;
+	case mvt_double:
+		return val.numeric_value.double_value;
+	case mvt_string:
+		return val.get_string_value();
+	default:
+		return std::string{};
+	}
+}
+
+// Split MVT command stream into coordinate rings (sequences between moveto commands).
+// Each ring is a vector of vertices. For polygons, closepath is implicit (MLT strips closing points).
+static std::vector<std::vector<Vertex>> extract_rings(const mvt_feature &feature) {
+	std::vector<std::vector<Vertex>> rings;
+
+	for (size_t i = 0; i < feature.geometry.size(); i++) {
+		const auto &g = feature.geometry[i];
+		if (g.op == mvt_moveto) {
+			rings.emplace_back();
+			rings.back().push_back({static_cast<int32_t>(g.x), static_cast<int32_t>(g.y)});
+		} else if (g.op == mvt_lineto) {
+			rings.back().push_back({static_cast<int32_t>(g.x), static_cast<int32_t>(g.y)});
+		}
+		// mvt_closepath: polygon ring close — MLT stores without closing point
+	}
+	return rings;
+}
+
+static mlt::Encoder::Geometry convert_geometry(const mvt_feature &feature) {
+	mlt::Encoder::Geometry geom;
+
+	auto rings = extract_rings(feature);
+
+	switch (feature.type) {
+	case mvt_point:
+		if (rings.size() == 1 && rings[0].size() == 1) {
+			geom.type = mlt::Encoder::GeometryType::POINT;
+			geom.coordinates = std::move(rings[0]);
+		} else {
+			geom.type = mlt::Encoder::GeometryType::MULTIPOINT;
+			for (auto &ring : rings) {
+				for (auto &v : ring) {
+					geom.coordinates.push_back(v);
+				}
+			}
+		}
+		break;
+
+	case mvt_linestring:
+		if (rings.size() == 1) {
+			geom.type = mlt::Encoder::GeometryType::LINESTRING;
+			geom.coordinates = std::move(rings[0]);
+		} else {
+			geom.type = mlt::Encoder::GeometryType::MULTILINESTRING;
+			geom.parts = std::move(rings);
+		}
+		break;
+
+	case mvt_polygon: {
+		// Outer rings are clockwise (positive area), holes are counter-clockwise.
+		// Group into polygons: each outer ring starts a new polygon.
+		std::vector<std::vector<std::vector<Vertex>>> polygons;
+
+		for (auto &ring : rings) {
+			// Signed area to detect winding: positive = clockwise = outer ring (in MVT screen coords)
+			long long area2 = 0;
+			for (size_t i = 0; i < ring.size(); i++) {
+				size_t j = (i + 1) % ring.size();
+				area2 += (long long) ring[i].x * ring[j].y - (long long) ring[j].x * ring[i].y;
+			}
+
+			if (area2 >= 0) {
+				// Outer ring — start new polygon
+				polygons.emplace_back();
+			}
+			if (!polygons.empty()) {
+				polygons.back().push_back(std::move(ring));
+			}
+		}
+
+		if (polygons.size() == 1) {
+			geom.type = mlt::Encoder::GeometryType::POLYGON;
+			for (auto &ring : polygons[0]) {
+				geom.ringSizes.push_back(static_cast<uint32_t>(ring.size()));
+				geom.coordinates.insert(geom.coordinates.end(), ring.begin(), ring.end());
+			}
+		} else {
+			geom.type = mlt::Encoder::GeometryType::MULTIPOLYGON;
+			for (auto &poly : polygons) {
+				std::vector<Vertex> part_verts;
+				std::vector<uint32_t> part_rings;
+				for (auto &ring : poly) {
+					part_rings.push_back(static_cast<uint32_t>(ring.size()));
+					part_verts.insert(part_verts.end(), ring.begin(), ring.end());
+				}
+				geom.parts.push_back(std::move(part_verts));
+				geom.partRingSizes.push_back(std::move(part_rings));
+			}
+		}
+		break;
+	}
+	}
+
+	return geom;
+}
+
+static mlt::Encoder::Layer convert_layer(const mvt_layer &layer) {
+	mlt::Encoder::Layer out;
+	out.name = layer.name;
+	out.extent = static_cast<uint32_t>(layer.extent);
+
+	for (const auto &feature : layer.features) {
+		mlt::Encoder::Feature f;
+		f.id = feature.id;
+		f.geometry = convert_geometry(feature);
+
+		for (size_t t = 0; t + 1 < feature.tags.size(); t += 2) {
+			unsigned key_idx = feature.tags[t];
+			unsigned val_idx = feature.tags[t + 1];
+			if (key_idx < layer.keys.size() && val_idx < layer.values.size()) {
+				const auto &val = layer.values[val_idx];
+				if (val.type != mvt_null) {
+					f.properties[layer.keys[key_idx]] = convert_value(val);
+				}
+			}
+		}
+
+		out.features.push_back(std::move(f));
+	}
+
+	return out;
+}
+
+std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretessellate) {
+	mlt::Encoder encoder;
+	mlt::EncoderConfig config;
+	config.sortFeatures = sort_features;
+	config.preTessellate = pretessellate;
+
+	bool any_has_id = false;
+	for (const auto &layer : tile.layers) {
+		for (const auto &feature : layer.features) {
+			if (feature.has_id) {
+				any_has_id = true;
+				break;
+			}
+		}
+		if (any_has_id) break;
+	}
+	config.includeIds = any_has_id;
+
+	std::vector<mlt::Encoder::Layer> layers;
+	layers.reserve(tile.layers.size());
+	for (const auto &layer : tile.layers) {
+		layers.push_back(convert_layer(layer));
+	}
+
+	auto bytes = encoder.encode(layers, config);
+	return std::string(reinterpret_cast<const char *>(bytes.data()), bytes.size());
+}

--- a/mlt.hpp
+++ b/mlt.hpp
@@ -4,6 +4,26 @@
 #include <string>
 #include "mvt.hpp"
 
+// The tile format to write, and the MLT encoder options to write it with,
+// as selected on the command line.
+extern int output_format;
+extern bool mlt_sort_features;
+extern bool mlt_pretessellate;
+
+// Set output_format from an --output-format argument, complaining and
+// exiting if it names a format we can't write.
+void set_output_format(char **argv, const char *format);
+
+// What this tile format is called in tileset metadata
+const char *tile_format_name(int format);
+
+// What tiles of this format are named in a tile directory
+const char *tile_format_extension(int format);
+
+// Encode a tile in the specified format, using whichever MLT encoder
+// options were selected on the command line
+std::string encode_tile(mvt_tile &tile, int format);
+
 std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretessellate);
 
 // Does this (already decompressed) tile look like MapLibre Tile rather than

--- a/mlt.hpp
+++ b/mlt.hpp
@@ -6,4 +6,12 @@
 
 std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretessellate);
 
+// Does this (already decompressed) tile look like MapLibre Tile rather than
+// Mapbox Vector Tile data?
+bool is_mlt(const std::string &message);
+
+// Decode a MapLibre Tile into the equivalent vector tile, returning false
+// (and complaining to stderr) if it can't be parsed.
+bool decode_mlt(const std::string &message, mvt_tile &out);
+
 #endif

--- a/mlt.hpp
+++ b/mlt.hpp
@@ -1,0 +1,9 @@
+#ifndef MLT_HPP
+#define MLT_HPP
+
+#include <string>
+#include "mvt.hpp"
+
+std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretessellate);
+
+#endif

--- a/mlt.hpp
+++ b/mlt.hpp
@@ -24,14 +24,17 @@ const char *tile_format_extension(int format);
 // options were selected on the command line
 std::string encode_tile(mvt_tile &tile, int format);
 
+#ifndef NO_MLT
 std::string encode_as_mlt(const mvt_tile &tile, bool sort_features, bool pretessellate);
+#endif
 
 // Does this (already decompressed) tile look like MapLibre Tile rather than
 // Mapbox Vector Tile data?
 bool is_mlt(const std::string &message);
 
 // Decode a MapLibre Tile into the equivalent vector tile, returning false
-// (and complaining to stderr) if it can't be parsed.
+// (and complaining to stderr) if it can't be parsed, or if this build
+// doesn't have MLT support compiled in.
 bool decode_mlt(const std::string &message, mvt_tile &out);
 
 #endif

--- a/mlt_decode.cpp
+++ b/mlt_decode.cpp
@@ -1,0 +1,291 @@
+#include "mlt.hpp"
+
+#include <mlt/decoder.hpp>
+#include <mlt/geometry.hpp>
+#include <mlt/layer.hpp>
+#include <mlt/properties.hpp>
+#include <mlt/tile.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace {
+
+bool read_varint(const char *&p, const char *end, unsigned long long &out) {
+	out = 0;
+	int shift = 0;
+
+	while (p < end) {
+		unsigned char c = (unsigned char) *p++;
+		if (shift > 63) {
+			return false;
+		}
+		out |= ((unsigned long long) (c & 0x7F)) << shift;
+		if ((c & 0x80) == 0) {
+			return true;
+		}
+		shift += 7;
+	}
+
+	return false;
+}
+
+long long round_coord(float v) {
+	return (long long) std::llround(v);
+}
+
+// Append a sequence of coordinates as a moveto followed by linetos. Rings
+// come out of the MLT decoder explicitly closed, but MVT rings are closed
+// implicitly by the closepath operation, so the repeated final point is
+// dropped.
+void add_line(mvt_feature &feature, const mlt::CoordVec &coords, bool ring) {
+	size_t n = coords.size();
+
+	if (ring && n > 1 && coords.front() == coords.back()) {
+		n--;
+	}
+
+	for (size_t i = 0; i < n; i++) {
+		feature.geometry.emplace_back(i == 0 ? mvt_moveto : mvt_lineto,
+					      round_coord(coords[i].x), round_coord(coords[i].y));
+	}
+
+	if (ring && n > 0) {
+		feature.geometry.emplace_back(mvt_closepath, 0, 0);
+	}
+}
+
+void convert_geometry(const mlt::geometry::Geometry &geom, mvt_feature &feature) {
+	using GeometryType = mlt::metadata::tileset::GeometryType;
+	namespace geometry = mlt::geometry;
+
+	switch (geom.type) {
+	case GeometryType::POINT: {
+		const auto &point = static_cast<const geometry::Point &>(geom);
+		feature.type = mvt_point;
+		feature.geometry.emplace_back(mvt_moveto,
+					      round_coord(point.getCoordinate().x),
+					      round_coord(point.getCoordinate().y));
+		break;
+	}
+
+	case GeometryType::MULTIPOINT: {
+		const auto &multipoint = static_cast<const geometry::MultiPoint &>(geom);
+		feature.type = mvt_point;
+		for (const auto &coord : multipoint.getCoordinates()) {
+			feature.geometry.emplace_back(mvt_moveto, round_coord(coord.x), round_coord(coord.y));
+		}
+		break;
+	}
+
+	case GeometryType::LINESTRING: {
+		const auto &linestring = static_cast<const geometry::LineString &>(geom);
+		feature.type = mvt_linestring;
+		add_line(feature, linestring.getCoordinates(), false);
+		break;
+	}
+
+	case GeometryType::MULTILINESTRING: {
+		const auto &multilinestring = static_cast<const geometry::MultiLineString &>(geom);
+		feature.type = mvt_linestring;
+		for (const auto &linestring : multilinestring.getLineStrings()) {
+			add_line(feature, linestring, false);
+		}
+		break;
+	}
+
+	case GeometryType::POLYGON: {
+		const auto &polygon = static_cast<const geometry::Polygon &>(geom);
+		feature.type = mvt_polygon;
+		for (const auto &ring : polygon.getRings()) {
+			add_line(feature, ring, true);
+		}
+		break;
+	}
+
+	case GeometryType::MULTIPOLYGON: {
+		const auto &multipolygon = static_cast<const geometry::MultiPolygon &>(geom);
+		feature.type = mvt_polygon;
+		for (const auto &polygon : multipolygon.getPolygons()) {
+			for (const auto &ring : polygon) {
+				add_line(feature, ring, true);
+			}
+		}
+		break;
+	}
+	}
+}
+
+// Converts one MLT property into the equivalent MVT value, returning false
+// for properties that MVT has no way to represent, which are left off the
+// feature instead.
+struct property_converter {
+	mvt_value &out;
+	const std::shared_ptr<std::string> &pool;
+
+	bool operator()(std::nullptr_t) const {
+		return false;
+	}
+
+	bool operator()(bool v) const {
+		out.type = mvt_bool;
+		out.numeric_value.bool_value = v;
+		return true;
+	}
+
+	bool operator()(std::int32_t v) const {
+		out.type = mvt_int;
+		out.numeric_value.int_value = v;
+		return true;
+	}
+
+	bool operator()(std::int64_t v) const {
+		out.type = mvt_int;
+		out.numeric_value.int_value = v;
+		return true;
+	}
+
+	bool operator()(std::uint32_t v) const {
+		out.type = mvt_uint;
+		out.numeric_value.uint_value = v;
+		return true;
+	}
+
+	bool operator()(std::uint64_t v) const {
+		out.type = mvt_uint;
+		out.numeric_value.uint_value = v;
+		return true;
+	}
+
+	bool operator()(float v) const {
+		out.type = mvt_float;
+		out.numeric_value.float_value = v;
+		return true;
+	}
+
+	bool operator()(double v) const {
+		out.type = mvt_double;
+		out.numeric_value.double_value = v;
+		return true;
+	}
+
+	bool operator()(std::string_view v) const {
+		out.s = pool;
+		out.set_string_value(v);
+		return true;
+	}
+
+	template <typename T>
+	bool operator()(const std::optional<T> &v) const {
+		if (v.has_value()) {
+			return (*this)(*v);
+		}
+		return false;
+	}
+};
+
+void convert_layer(const mlt::Layer &in, mvt_layer &out, const std::shared_ptr<std::string> &pool) {
+	out.version = 2;
+	out.name = in.getName();
+	out.extent = in.getExtent();
+
+	// The property columns are held in an unordered map, so sort the names
+	// to keep the attributes of the decoded tile in a stable order.
+	std::vector<std::pair<const std::string *, const mlt::PresentProperties *>> columns;
+	columns.reserve(in.getProperties().size());
+	for (const auto &property : in.getProperties()) {
+		columns.emplace_back(&property.first, &property.second);
+	}
+	std::sort(columns.begin(), columns.end(), [](auto const &a, auto const &b) {
+		return *a.first < *b.first;
+	});
+
+	out.features.reserve(in.getFeatures().size());
+
+	for (const auto &in_feature : in.getFeatures()) {
+		mvt_feature feature;
+
+		if (in_feature.getID()) {
+			feature.id = *in_feature.getID();
+			feature.has_id = true;
+		}
+
+		convert_geometry(in_feature.getGeometry(), feature);
+
+		for (const auto &column : columns) {
+			auto property = column.second->getProperty(in_feature.getIndex());
+			if (!property) {
+				continue;
+			}
+
+			mvt_value value;
+			if (std::visit(property_converter{value, pool}, *property)) {
+				out.tag(feature, *column.first, value);
+			}
+		}
+
+		out.features.push_back(std::move(feature));
+	}
+}
+
+}  // namespace
+
+bool is_mlt(const std::string &message) {
+	// An MLT tile is a sequence of layers, each of which is a varint byte
+	// count followed by a varint tag whose only defined value is 1.
+	//
+	// An MVT tile is a protobuf whose only field is the repeated layer
+	// field 3, so it begins with the byte 0x1a followed by the byte count
+	// of a layer, which can never be as short as the single byte that
+	// would be needed to masquerade as an MLT layer tag.
+
+	const char *p = message.data();
+	const char *end = p + message.size();
+
+	unsigned long long layer_length;
+	if (!read_varint(p, end, layer_length)) {
+		return false;
+	}
+	if (layer_length < 2 || layer_length > (unsigned long long) (end - p)) {
+		return false;
+	}
+
+	unsigned long long layer_tag;
+	if (!read_varint(p, end, layer_tag)) {
+		return false;
+	}
+
+	return layer_tag == 1;
+}
+
+bool decode_mlt(const std::string &message, mvt_tile &out) {
+	try {
+		mlt::Decoder decoder(true);
+		mlt::MapLibreTile tile = decoder.decode(mlt::DataView(message.data(), message.size()));
+
+		std::shared_ptr<std::string> pool = std::make_shared<std::string>();
+
+		out.layers.clear();
+		out.layers.reserve(tile.getLayers().size());
+
+		for (const auto &layer : tile.getLayers()) {
+			mvt_layer out_layer;
+			convert_layer(layer, out_layer, pool);
+			out.layers.push_back(std::move(out_layer));
+		}
+
+		return true;
+	} catch (std::exception const &e) {
+		fprintf(stderr, "MLT decoding error: %s\n", e.what());
+		return false;
+	}
+}

--- a/mlt_decode.cpp
+++ b/mlt_decode.cpp
@@ -1,11 +1,5 @@
 #include "mlt.hpp"
 
-#include <mlt/decoder.hpp>
-#include <mlt/geometry.hpp>
-#include <mlt/layer.hpp>
-#include <mlt/properties.hpp>
-#include <mlt/tile.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -17,6 +11,14 @@
 #include <string_view>
 #include <variant>
 #include <vector>
+
+#ifndef NO_MLT
+#include <mlt/decoder.hpp>
+#include <mlt/geometry.hpp>
+#include <mlt/layer.hpp>
+#include <mlt/properties.hpp>
+#include <mlt/tile.hpp>
+#endif
 
 namespace {
 
@@ -38,6 +40,8 @@ bool read_varint(const char *&p, const char *end, unsigned long long &out) {
 
 	return false;
 }
+
+#ifndef NO_MLT
 
 long long round_coord(float v) {
 	return (long long) std::llround(v);
@@ -237,6 +241,8 @@ void convert_layer(const mlt::Layer &in, mvt_layer &out, const std::shared_ptr<s
 	}
 }
 
+#endif
+
 }  // namespace
 
 bool is_mlt(const std::string &message) {
@@ -267,6 +273,18 @@ bool is_mlt(const std::string &message) {
 	return layer_tag == 1;
 }
 
+#ifdef NO_MLT
+
+bool decode_mlt(const std::string &message, mvt_tile &out) {
+	(void) message;
+	(void) out;
+
+	fprintf(stderr, "This build was compiled without MapLibre Tile support\n");
+	return false;
+}
+
+#else
+
 bool decode_mlt(const std::string &message, mvt_tile &out) {
 	try {
 		mlt::Decoder decoder(true);
@@ -289,3 +307,5 @@ bool decode_mlt(const std::string &message, mvt_tile &out) {
 		return false;
 	}
 }
+
+#endif

--- a/mvt.cpp
+++ b/mvt.cpp
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <ctype.h>
 #include "mvt.hpp"
+#include "mlt.hpp"
 #include "geometry.hpp"
 #include "protozero/varint.hpp"
 #include "protozero/pbf_reader.hpp"
@@ -125,6 +126,10 @@ bool mvt_tile::decode(const std::string &message, bool &was_compressed) {
 	} else {
 		src = message;
 		was_compressed = false;
+	}
+
+	if (is_mlt(src)) {
+		return decode_mlt(src, *this);
 	}
 
 	protozero::pbf_reader reader(src);

--- a/mvt.hpp
+++ b/mvt.hpp
@@ -17,6 +17,10 @@
 struct mvt_value;
 struct mvt_layer;
 
+// Which of the two vector tile encodings a tile is written in
+#define OUTPUT_MVT 0
+#define OUTPUT_MLT 1
+
 enum mvt_operation {
 	mvt_moveto = 1,
 	mvt_lineto = 2,

--- a/overzoom.cpp
+++ b/overzoom.cpp
@@ -5,6 +5,7 @@
 #include <set>
 #include "errors.hpp"
 #include "mvt.hpp"
+#include "mlt.hpp"
 #include "geometry.hpp"
 #include "evaluator.hpp"
 #include "attribute.hpp"
@@ -85,6 +86,9 @@ int main(int argc, char **argv) {
 		{"source-tile", required_argument, 0, 't'},
 		{"no-tile-compression", no_argument, 0, 'd' & 0x1F},
 		{"deduplicate-by-id", no_argument, 0, 'i' & 0x1F},
+		{"output-format", required_argument, 0, 'f' & 0x1F},
+		{"pretessellate", no_argument, 0, 'p' & 0x1F},
+		{"no-mlt-feature-sort", no_argument, 0, 'r' & 0x1F},
 
 		{0, 0, 0, 0},
 	};
@@ -171,6 +175,18 @@ int main(int argc, char **argv) {
 			deduplicate_by_id = true;
 			break;
 		}
+
+		case 'f' & 0x1F:
+			set_output_format(argv, optarg);
+			break;
+
+		case 'p' & 0x1F:
+			mlt_pretessellate = true;
+			break;
+
+		case 'r' & 0x1F:
+			mlt_sort_features = false;
+			break;
 
 		default:
 			fprintf(stderr, "Unrecognized flag -%c\n", i);
@@ -264,7 +280,7 @@ int main(int argc, char **argv) {
 			its.push_back(std::move(t));
 		}
 
-		out = overzoom(its, nz, nx, ny, detail, buffer, keep, exclude, exclude_prefix, do_compress, NULL, demultiply, json_filter, preserve_input_order, attribute_accum, unidecode_data, simplification, tiny_polygon_size, std::vector<mvt_layer>(), "", "", SIZE_MAX, std::vector<clipbbox>(), deduplicate_by_id);
+		out = overzoom(its, nz, nx, ny, detail, buffer, keep, exclude, exclude_prefix, do_compress, NULL, demultiply, json_filter, preserve_input_order, attribute_accum, unidecode_data, simplification, tiny_polygon_size, std::vector<mvt_layer>(), "", "", SIZE_MAX, std::vector<clipbbox>(), deduplicate_by_id, output_format);
 	}
 
 	FILE *f = fopen(outfile, "wb");

--- a/tests/mlt/join-out.mbtiles.json
+++ b/tests/mlt/join-out.mbtiles.json
@@ -1,0 +1,104 @@
+{ "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.915039,37.160317,-122.343750,37.961523",
+"bounds": "-122.915039,37.160317,-122.343750,37.961523",
+"center": "-122.350000,37.200000,5",
+"description": "tests/mlt/mvt-source.mbtiles",
+"format": "mlt",
+"json": "{\"vector_layers\":[{\"id\":\"roundtrip\",\"description\":\"\",\"minzoom\":0,\"maxzoom\":5,\"fields\":{\"active\":\"Boolean\",\"count\":\"Number\",\"kind\":\"String\",\"name\":\"String\",\"nested\":\"String\",\"ratio\":\"Number\",\"unicode\":\"String\"}}],\"tilestats\":{\"layerCount\":1,\"layers\":[{\"layer\":\"roundtrip\",\"count\":33,\"geometry\":\"LineString\",\"attributeCount\":7,\"attributes\":[{\"attribute\":\"active\",\"count\":2,\"type\":\"boolean\",\"values\":[false,true]},{\"attribute\":\"count\",\"count\":6,\"type\":\"number\",\"values\":[-200,100,300,4000000000,500,600],\"min\":-200,\"max\":4000000000},{\"attribute\":\"kind\",\"count\":3,\"type\":\"string\",\"values\":[\"line\",\"point\",\"polygon\"]},{\"attribute\":\"name\",\"count\":7,\"type\":\"string\",\"values\":[\"line\",\"multiline\",\"multipoint\",\"multipolygon\",\"no id\",\"point\",\"polygon with hole\"]},{\"attribute\":\"nested\",\"count\":1,\"type\":\"string\",\"values\":[\"{\\\"a\\\":1,\\\"b\\\":\\\"two\\\"}\"]},{\"attribute\":\"ratio\",\"count\":5,\"type\":\"number\",\"values\":[-0.25,0.125,1.5,2,3.25],\"min\":-0.25,\"max\":3.25},{\"attribute\":\"unicode\",\"count\":1,\"type\":\"string\",\"values\":[\"påíñtß 堤防\"]}]}]}}",
+"maxzoom": "5",
+"minzoom": "0",
+"name": "tests/mlt/mvt-source.mbtiles",
+"strategies": "[{\"dropped_by_rate\":2,\"tiny_polygons\":1},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":1}]",
+"type": "overlay",
+"version": "2"
+}, "features": [
+{ "type": "FeatureCollection", "properties": { "zoom": 0, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.926868 ], [ -122.431641, 37.857507 ], [ -122.519531, 37.926868 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.579413 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.579413 ], [ -122.431641, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.718590 ], [ -122.431641, 37.718590 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.431641, 37.579413 ], [ -122.431641, 37.370157 ], [ -122.783203, 37.370157 ], [ -122.783203, 37.579413 ], [ -122.431641, 37.579413 ] ], [ [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.519531, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.343750, 37.300275 ], [ -122.343750, 37.160317 ], [ -122.519531, 37.160317 ], [ -122.519531, 37.300275 ], [ -122.343750, 37.300275 ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 1, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.892196 ], [ -122.431641, 37.857507 ], [ -122.563477, 37.961523 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.614231 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.614231 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.683820 ], [ -122.519531, 37.753344 ], [ -122.387695, 37.683820 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.783203, 37.405074 ], [ -122.783203, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.439974 ], [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.695312, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.915039, 37.195331 ], [ -122.915039, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.563477, 37.230328 ], [ -122.431641, 37.230328 ], [ -122.431641, 37.265310 ], [ -122.563477, 37.265310 ], [ -122.563477, 37.230328 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 2, "x": 0, "y": 1 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.892196 ], [ -122.453613, 37.857507 ], [ -122.541504, 37.944198 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.607422, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.701207 ], [ -122.497559, 37.753344 ], [ -122.387695, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.805176, 37.405074 ], [ -122.805176, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.457418 ], [ -122.497559, 37.457418 ], [ -122.497559, 37.492294 ], [ -122.695312, 37.492294 ], [ -122.695312, 37.457418 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.893066, 37.195331 ], [ -122.893066, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.541504, 37.212832 ], [ -122.453613, 37.212832 ], [ -122.453613, 37.282795 ], [ -122.541504, 37.282795 ], [ -122.541504, 37.212832 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 3, "x": 1, "y": 3 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.453613, 37.848833 ], [ -122.552490, 37.952861 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.701207 ], [ -122.497559, 37.744657 ], [ -122.398682, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.544577 ], [ -122.398682, 37.396346 ], [ -122.794189, 37.396346 ], [ -122.794189, 37.544577 ], [ -122.398682, 37.544577 ] ], [ [ -122.695312, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.695312, 37.501010 ], [ -122.695312, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.904053, 37.195331 ], [ -122.904053, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.195331 ], [ -122.596436, 37.195331 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.552490, 37.221580 ], [ -122.453613, 37.221580 ], [ -122.453613, 37.282795 ], [ -122.552490, 37.282795 ], [ -122.552490, 37.221580 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 4, "x": 2, "y": 6 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.448120, 37.848833 ], [ -122.546997, 37.948529 ] ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.696861 ], [ -122.497559, 37.749001 ], [ -122.398682, 37.696861 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.898560, 37.199706 ], [ -122.898560, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.596436, 37.199706 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.546997, 37.217206 ], [ -122.448120, 37.217206 ], [ -122.448120, 37.278424 ], [ -122.546997, 37.278424 ], [ -122.546997, 37.217206 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 5, "x": 5, "y": 12 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.500305, 37.900865 ], [ -122.450867, 37.851001 ], [ -122.549744, 37.950695 ] ] } }
+,
+{ "type": "Feature", "id": 1, "properties": { "active": true, "count": 100, "kind": "point", "name": "point", "nested": "{\"a\":1,\"b\":\"two\"}", "ratio": 1.5 }, "geometry": { "type": "Point", "coordinates": [ -122.398682, 37.798933 ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.599000 ], [ -122.599182, 37.649034 ] ], [ [ -122.500305, 37.599000 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.599182, 37.699034 ], [ -122.500305, 37.749001 ], [ -122.398682, 37.699034 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.450877 ], [ -122.500305, 37.450877 ], [ -122.500305, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.450877 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.901306, 37.199706 ], [ -122.901306, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.599182, 37.199706 ], [ -122.599182, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.549744, 37.219393 ], [ -122.450867, 37.219393 ], [ -122.450867, 37.280609 ], [ -122.549744, 37.280609 ], [ -122.549744, 37.219393 ] ] ] ] } }
+] }
+] }
+] }

--- a/tests/mlt/joined.mbtiles.json
+++ b/tests/mlt/joined.mbtiles.json
@@ -1,0 +1,104 @@
+{ "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.915039,37.160317,-122.343750,37.961523",
+"bounds": "-122.915039,37.160317,-122.343750,37.961523",
+"center": "-122.350000,37.200000,5",
+"description": "tests/mlt/roundtrip.mbtiles",
+"format": "pbf",
+"json": "{\"vector_layers\":[{\"id\":\"roundtrip\",\"description\":\"\",\"minzoom\":0,\"maxzoom\":5,\"fields\":{\"active\":\"Boolean\",\"count\":\"Number\",\"kind\":\"String\",\"name\":\"String\",\"nested\":\"String\",\"ratio\":\"Number\",\"unicode\":\"String\"}}],\"tilestats\":{\"layerCount\":1,\"layers\":[{\"layer\":\"roundtrip\",\"count\":33,\"geometry\":\"LineString\",\"attributeCount\":7,\"attributes\":[{\"attribute\":\"active\",\"count\":2,\"type\":\"boolean\",\"values\":[false,true]},{\"attribute\":\"count\",\"count\":6,\"type\":\"number\",\"values\":[-200,100,300,4000000000,500,600],\"min\":-200,\"max\":4000000000},{\"attribute\":\"kind\",\"count\":3,\"type\":\"string\",\"values\":[\"line\",\"point\",\"polygon\"]},{\"attribute\":\"name\",\"count\":7,\"type\":\"string\",\"values\":[\"line\",\"multiline\",\"multipoint\",\"multipolygon\",\"no id\",\"point\",\"polygon with hole\"]},{\"attribute\":\"nested\",\"count\":1,\"type\":\"string\",\"values\":[\"{\\\"a\\\":1,\\\"b\\\":\\\"two\\\"}\"]},{\"attribute\":\"ratio\",\"count\":5,\"type\":\"number\",\"values\":[-0.25,0.125,1.5,2,3.25],\"min\":-0.25,\"max\":3.25},{\"attribute\":\"unicode\",\"count\":1,\"type\":\"string\",\"values\":[\"påíñtß 堤防\"]}]}]}}",
+"maxzoom": "5",
+"minzoom": "0",
+"name": "tests/mlt/roundtrip.mbtiles",
+"strategies": "[{\"dropped_by_rate\":2,\"tiny_polygons\":1},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":1}]",
+"type": "overlay",
+"version": "2"
+}, "features": [
+{ "type": "FeatureCollection", "properties": { "zoom": 0, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.926868 ], [ -122.431641, 37.857507 ], [ -122.519531, 37.926868 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.579413 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.579413 ], [ -122.431641, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.718590 ], [ -122.431641, 37.718590 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.431641, 37.579413 ], [ -122.431641, 37.370157 ], [ -122.783203, 37.370157 ], [ -122.783203, 37.579413 ], [ -122.431641, 37.579413 ] ], [ [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.519531, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.343750, 37.300275 ], [ -122.343750, 37.160317 ], [ -122.519531, 37.160317 ], [ -122.519531, 37.300275 ], [ -122.343750, 37.300275 ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 1, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.892196 ], [ -122.431641, 37.857507 ], [ -122.563477, 37.961523 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.614231 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.614231 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.683820 ], [ -122.519531, 37.753344 ], [ -122.387695, 37.683820 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.783203, 37.405074 ], [ -122.783203, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.439974 ], [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.695312, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.915039, 37.195331 ], [ -122.915039, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.563477, 37.230328 ], [ -122.431641, 37.230328 ], [ -122.431641, 37.265310 ], [ -122.563477, 37.265310 ], [ -122.563477, 37.230328 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 2, "x": 0, "y": 1 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.892196 ], [ -122.453613, 37.857507 ], [ -122.541504, 37.944198 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.607422, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.701207 ], [ -122.497559, 37.753344 ], [ -122.387695, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.805176, 37.405074 ], [ -122.805176, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.457418 ], [ -122.497559, 37.457418 ], [ -122.497559, 37.492294 ], [ -122.695312, 37.492294 ], [ -122.695312, 37.457418 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.893066, 37.195331 ], [ -122.893066, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.541504, 37.212832 ], [ -122.453613, 37.212832 ], [ -122.453613, 37.282795 ], [ -122.541504, 37.282795 ], [ -122.541504, 37.212832 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 3, "x": 1, "y": 3 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.453613, 37.848833 ], [ -122.552490, 37.952861 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.701207 ], [ -122.497559, 37.744657 ], [ -122.398682, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.544577 ], [ -122.398682, 37.396346 ], [ -122.794189, 37.396346 ], [ -122.794189, 37.544577 ], [ -122.398682, 37.544577 ] ], [ [ -122.695312, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.695312, 37.501010 ], [ -122.695312, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.904053, 37.195331 ], [ -122.904053, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.195331 ], [ -122.596436, 37.195331 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.552490, 37.221580 ], [ -122.453613, 37.221580 ], [ -122.453613, 37.282795 ], [ -122.552490, 37.282795 ], [ -122.552490, 37.221580 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 4, "x": 2, "y": 6 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.448120, 37.848833 ], [ -122.546997, 37.948529 ] ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.696861 ], [ -122.497559, 37.749001 ], [ -122.398682, 37.696861 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.898560, 37.199706 ], [ -122.898560, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.596436, 37.199706 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.546997, 37.217206 ], [ -122.448120, 37.217206 ], [ -122.448120, 37.278424 ], [ -122.546997, 37.278424 ], [ -122.546997, 37.217206 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 5, "x": 5, "y": 12 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.500305, 37.900865 ], [ -122.450867, 37.851001 ], [ -122.549744, 37.950695 ] ] } }
+,
+{ "type": "Feature", "id": 1, "properties": { "active": true, "count": 100, "kind": "point", "name": "point", "nested": "{\"a\":1,\"b\":\"two\"}", "ratio": 1.5 }, "geometry": { "type": "Point", "coordinates": [ -122.398682, 37.798933 ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.599000 ], [ -122.599182, 37.649034 ] ], [ [ -122.500305, 37.599000 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.599182, 37.699034 ], [ -122.500305, 37.749001 ], [ -122.398682, 37.699034 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.450877 ], [ -122.500305, 37.450877 ], [ -122.500305, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.450877 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.901306, 37.199706 ], [ -122.901306, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.599182, 37.199706 ], [ -122.599182, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.549744, 37.219393 ], [ -122.450867, 37.219393 ], [ -122.450867, 37.280609 ], [ -122.549744, 37.280609 ], [ -122.549744, 37.219393 ] ] ] ] } }
+] }
+] }
+] }

--- a/tests/mlt/overzoom.json
+++ b/tests/mlt/overzoom.json
@@ -1,0 +1,13 @@
+{ "type": "FeatureCollection", "properties": { "zoom": 4, "x": 2, "y": 6 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.892196 ], [ -122.453613, 37.857507 ], [ -122.541504, 37.944198 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.607422, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.701207 ], [ -122.497559, 37.753344 ], [ -122.387695, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.805176, 37.405074 ], [ -122.805176, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.457418 ], [ -122.497559, 37.457418 ], [ -122.497559, 37.492294 ], [ -122.695312, 37.492294 ], [ -122.695312, 37.457418 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.893066, 37.195331 ], [ -122.893066, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.541504, 37.212832 ], [ -122.453613, 37.212832 ], [ -122.453613, 37.282795 ], [ -122.541504, 37.282795 ], [ -122.541504, 37.212832 ] ] ] ] } }
+] }
+] }

--- a/tests/mlt/points.geojson
+++ b/tests/mlt/points.geojson
@@ -1,0 +1,5 @@
+{"type":"FeatureCollection","features":[
+{"type":"Feature","id":1,"properties":{"name":"point1","count":100,"active":true},"geometry":{"type":"Point","coordinates":[-122.4,37.8]}},
+{"type":"Feature","id":2,"properties":{"name":"point2","count":200,"active":false},"geometry":{"type":"Point","coordinates":[-122.5,37.9]}},
+{"type":"Feature","id":3,"properties":{"name":"point3","count":300},"geometry":{"type":"Point","coordinates":[-122.6,38.0]}}
+]}

--- a/tests/mlt/roundtrip-dir.json
+++ b/tests/mlt/roundtrip-dir.json
@@ -1,0 +1,104 @@
+{ "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.900000,37.200000,-122.350000,37.950000",
+"bounds": "-122.900000,37.200000,-122.350000,37.950000",
+"center": "-122.350000,37.200000,5",
+"description": "tests/mlt/roundtrip-dir",
+"format": "mlt",
+"json": "{\"vector_layers\":[{\"id\":\"roundtrip\",\"description\":\"\",\"minzoom\":0,\"maxzoom\":5,\"fields\":{\"active\":\"Boolean\",\"count\":\"Number\",\"kind\":\"String\",\"name\":\"String\",\"nested\":\"String\",\"ratio\":\"Number\",\"unicode\":\"String\"}}],\"tilestats\":{\"layerCount\":1,\"layers\":[{\"layer\":\"roundtrip\",\"count\":7,\"geometry\":\"Point\",\"attributeCount\":7,\"attributes\":[{\"attribute\":\"active\",\"count\":2,\"type\":\"boolean\",\"values\":[false,true]},{\"attribute\":\"count\",\"count\":6,\"type\":\"number\",\"values\":[-200,100,300,4000000000,500,600],\"min\":-200,\"max\":4000000000},{\"attribute\":\"kind\",\"count\":3,\"type\":\"string\",\"values\":[\"line\",\"point\",\"polygon\"]},{\"attribute\":\"name\",\"count\":7,\"type\":\"string\",\"values\":[\"line\",\"multiline\",\"multipoint\",\"multipolygon\",\"no id\",\"point\",\"polygon with hole\"]},{\"attribute\":\"nested\",\"count\":1,\"type\":\"string\",\"values\":[\"{\\\"a\\\":1,\\\"b\\\":\\\"two\\\"}\"]},{\"attribute\":\"ratio\",\"count\":5,\"type\":\"number\",\"values\":[-0.25,0.125,1.5,2,3.25],\"min\":-0.25,\"max\":3.25},{\"attribute\":\"unicode\",\"count\":1,\"type\":\"string\",\"values\":[\"påíñtß 堤防\"]}]}]}}",
+"maxzoom": "5",
+"minzoom": "0",
+"name": "tests/mlt/roundtrip-dir",
+"strategies": "[{\"dropped_by_rate\":2,\"tiny_polygons\":1},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":1},{}]",
+"type": "overlay",
+"version": "2"
+}, "features": [
+{ "type": "FeatureCollection", "properties": { "zoom": 0, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.926868 ], [ -122.431641, 37.857507 ], [ -122.519531, 37.926868 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.579413 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.579413 ], [ -122.431641, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.718590 ], [ -122.431641, 37.718590 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.431641, 37.579413 ], [ -122.431641, 37.370157 ], [ -122.783203, 37.370157 ], [ -122.783203, 37.579413 ], [ -122.431641, 37.579413 ] ], [ [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.519531, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.343750, 37.300275 ], [ -122.343750, 37.160317 ], [ -122.519531, 37.160317 ], [ -122.519531, 37.300275 ], [ -122.343750, 37.300275 ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 1, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.892196 ], [ -122.431641, 37.857507 ], [ -122.563477, 37.961523 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.614231 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.614231 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.683820 ], [ -122.519531, 37.753344 ], [ -122.387695, 37.683820 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.783203, 37.405074 ], [ -122.783203, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.439974 ], [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.695312, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.915039, 37.195331 ], [ -122.915039, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.563477, 37.230328 ], [ -122.431641, 37.230328 ], [ -122.431641, 37.265310 ], [ -122.563477, 37.265310 ], [ -122.563477, 37.230328 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 2, "x": 0, "y": 1 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.892196 ], [ -122.453613, 37.857507 ], [ -122.541504, 37.944198 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.607422, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.701207 ], [ -122.497559, 37.753344 ], [ -122.387695, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.805176, 37.405074 ], [ -122.805176, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.457418 ], [ -122.497559, 37.457418 ], [ -122.497559, 37.492294 ], [ -122.695312, 37.492294 ], [ -122.695312, 37.457418 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.893066, 37.195331 ], [ -122.893066, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.541504, 37.212832 ], [ -122.453613, 37.212832 ], [ -122.453613, 37.282795 ], [ -122.541504, 37.282795 ], [ -122.541504, 37.212832 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 3, "x": 1, "y": 3 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.453613, 37.848833 ], [ -122.552490, 37.952861 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.701207 ], [ -122.497559, 37.744657 ], [ -122.398682, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.544577 ], [ -122.398682, 37.396346 ], [ -122.794189, 37.396346 ], [ -122.794189, 37.544577 ], [ -122.398682, 37.544577 ] ], [ [ -122.695312, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.695312, 37.501010 ], [ -122.695312, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.904053, 37.195331 ], [ -122.904053, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.195331 ], [ -122.596436, 37.195331 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.552490, 37.221580 ], [ -122.453613, 37.221580 ], [ -122.453613, 37.282795 ], [ -122.552490, 37.282795 ], [ -122.552490, 37.221580 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 4, "x": 2, "y": 6 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.448120, 37.848833 ], [ -122.546997, 37.948529 ] ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.696861 ], [ -122.497559, 37.749001 ], [ -122.398682, 37.696861 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.898560, 37.199706 ], [ -122.898560, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.596436, 37.199706 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.546997, 37.217206 ], [ -122.448120, 37.217206 ], [ -122.448120, 37.278424 ], [ -122.546997, 37.278424 ], [ -122.546997, 37.217206 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 5, "x": 5, "y": 12 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.500305, 37.900865 ], [ -122.450867, 37.851001 ], [ -122.549744, 37.950695 ] ] } }
+,
+{ "type": "Feature", "id": 1, "properties": { "active": true, "count": 100, "kind": "point", "name": "point", "nested": "{\"a\":1,\"b\":\"two\"}", "ratio": 1.5 }, "geometry": { "type": "Point", "coordinates": [ -122.398682, 37.798933 ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.599000 ], [ -122.599182, 37.649034 ] ], [ [ -122.500305, 37.599000 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.599182, 37.699034 ], [ -122.500305, 37.749001 ], [ -122.398682, 37.699034 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.450877 ], [ -122.500305, 37.450877 ], [ -122.500305, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.450877 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.901306, 37.199706 ], [ -122.901306, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.599182, 37.199706 ], [ -122.599182, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.549744, 37.219393 ], [ -122.450867, 37.219393 ], [ -122.450867, 37.280609 ], [ -122.549744, 37.280609 ], [ -122.549744, 37.219393 ] ] ] ] } }
+] }
+] }
+] }

--- a/tests/mlt/roundtrip.geojson
+++ b/tests/mlt/roundtrip.geojson
@@ -1,0 +1,9 @@
+{"type":"FeatureCollection","features":[
+{"type":"Feature","id":1,"properties":{"name":"point","kind":"point","count":100,"ratio":1.5,"active":true,"nested":{"a":1,"b":"two"}},"geometry":{"type":"Point","coordinates":[-122.4,37.8]}},
+{"type":"Feature","id":2,"properties":{"name":"multipoint","kind":"point","count":-200,"ratio":-0.25,"active":false},"geometry":{"type":"MultiPoint","coordinates":[[-122.5,37.9],[-122.45,37.85],[-122.55,37.95]]}},
+{"type":"Feature","id":3,"properties":{"name":"line","kind":"line","count":300,"ratio":2},"geometry":{"type":"LineString","coordinates":[[-122.6,37.7],[-122.5,37.75],[-122.4,37.7]]}},
+{"type":"Feature","id":4,"properties":{"name":"multiline","kind":"line","count":4000000000,"ratio":0.125},"geometry":{"type":"MultiLineString","coordinates":[[[-122.7,37.6],[-122.6,37.65]],[[-122.5,37.6],[-122.4,37.65]]]}},
+{"type":"Feature","id":5,"properties":{"name":"polygon with hole","kind":"polygon","count":500,"ratio":3.25,"active":true},"geometry":{"type":"Polygon","coordinates":[[[-122.8,37.4],[-122.4,37.4],[-122.4,37.55],[-122.8,37.55],[-122.8,37.4]],[[-122.7,37.45],[-122.7,37.5],[-122.5,37.5],[-122.5,37.45],[-122.7,37.45]]]}},
+{"type":"Feature","id":6,"properties":{"name":"multipolygon","kind":"polygon","count":600},"geometry":{"type":"MultiPolygon","coordinates":[[[[-122.9,37.2],[-122.7,37.2],[-122.7,37.3],[-122.9,37.3],[-122.9,37.2]]],[[[-122.6,37.2],[-122.4,37.2],[-122.4,37.3],[-122.6,37.3],[-122.6,37.2]],[[-122.55,37.22],[-122.55,37.28],[-122.45,37.28],[-122.45,37.22],[-122.55,37.22]]]]}},
+{"type":"Feature","properties":{"name":"no id","kind":"point","unicode":"påíñtß 堤防"},"geometry":{"type":"Point","coordinates":[-122.35,37.75]}}
+]}

--- a/tests/mlt/roundtrip.mbtiles.json
+++ b/tests/mlt/roundtrip.mbtiles.json
@@ -1,0 +1,104 @@
+{ "type": "FeatureCollection", "properties": {
+"antimeridian_adjusted_bounds": "-122.900000,37.200000,-122.350000,37.950000",
+"bounds": "-122.900000,37.200000,-122.350000,37.950000",
+"center": "-122.350000,37.200000,5",
+"description": "tests/mlt/roundtrip.mbtiles",
+"format": "mlt",
+"json": "{\"vector_layers\":[{\"id\":\"roundtrip\",\"description\":\"\",\"minzoom\":0,\"maxzoom\":5,\"fields\":{\"active\":\"Boolean\",\"count\":\"Number\",\"kind\":\"String\",\"name\":\"String\",\"nested\":\"String\",\"ratio\":\"Number\",\"unicode\":\"String\"}}],\"tilestats\":{\"layerCount\":1,\"layers\":[{\"layer\":\"roundtrip\",\"count\":7,\"geometry\":\"Point\",\"attributeCount\":7,\"attributes\":[{\"attribute\":\"active\",\"count\":2,\"type\":\"boolean\",\"values\":[false,true]},{\"attribute\":\"count\",\"count\":6,\"type\":\"number\",\"values\":[-200,100,300,4000000000,500,600],\"min\":-200,\"max\":4000000000},{\"attribute\":\"kind\",\"count\":3,\"type\":\"string\",\"values\":[\"line\",\"point\",\"polygon\"]},{\"attribute\":\"name\",\"count\":7,\"type\":\"string\",\"values\":[\"line\",\"multiline\",\"multipoint\",\"multipolygon\",\"no id\",\"point\",\"polygon with hole\"]},{\"attribute\":\"nested\",\"count\":1,\"type\":\"string\",\"values\":[\"{\\\"a\\\":1,\\\"b\\\":\\\"two\\\"}\"]},{\"attribute\":\"ratio\",\"count\":5,\"type\":\"number\",\"values\":[-0.25,0.125,1.5,2,3.25],\"min\":-0.25,\"max\":3.25},{\"attribute\":\"unicode\",\"count\":1,\"type\":\"string\",\"values\":[\"påíñtß 堤防\"]}]}]}}",
+"maxzoom": "5",
+"minzoom": "0",
+"name": "tests/mlt/roundtrip.mbtiles",
+"strategies": "[{\"dropped_by_rate\":2,\"tiny_polygons\":1},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":2},{\"dropped_by_rate\":1},{}]",
+"type": "overlay",
+"version": "2"
+}, "features": [
+{ "type": "FeatureCollection", "properties": { "zoom": 0, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.926868 ], [ -122.431641, 37.857507 ], [ -122.519531, 37.926868 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.579413 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.579413 ], [ -122.431641, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.718590 ], [ -122.431641, 37.718590 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.431641, 37.579413 ], [ -122.431641, 37.370157 ], [ -122.783203, 37.370157 ], [ -122.783203, 37.579413 ], [ -122.431641, 37.579413 ] ], [ [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.519531, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.343750, 37.300275 ], [ -122.343750, 37.160317 ], [ -122.519531, 37.160317 ], [ -122.519531, 37.300275 ], [ -122.343750, 37.300275 ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 1, "x": 0, "y": 0 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.519531, 37.892196 ], [ -122.431641, 37.857507 ], [ -122.563477, 37.961523 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.614231 ], [ -122.607422, 37.649034 ] ], [ [ -122.519531, 37.614231 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.683820 ], [ -122.519531, 37.753344 ], [ -122.387695, 37.683820 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.783203, 37.405074 ], [ -122.783203, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.439974 ], [ -122.519531, 37.439974 ], [ -122.519531, 37.509726 ], [ -122.695312, 37.509726 ], [ -122.695312, 37.439974 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.915039, 37.195331 ], [ -122.915039, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.563477, 37.230328 ], [ -122.431641, 37.230328 ], [ -122.431641, 37.265310 ], [ -122.563477, 37.265310 ], [ -122.563477, 37.230328 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 2, "x": 0, "y": 1 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.892196 ], [ -122.453613, 37.857507 ], [ -122.541504, 37.944198 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.607422, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.387695, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.607422, 37.701207 ], [ -122.497559, 37.753344 ], [ -122.387695, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.387695, 37.544577 ], [ -122.387695, 37.405074 ], [ -122.805176, 37.405074 ], [ -122.805176, 37.544577 ], [ -122.387695, 37.544577 ] ], [ [ -122.695312, 37.457418 ], [ -122.497559, 37.457418 ], [ -122.497559, 37.492294 ], [ -122.695312, 37.492294 ], [ -122.695312, 37.457418 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.893066, 37.195331 ], [ -122.893066, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.387695, 37.300275 ], [ -122.387695, 37.195331 ], [ -122.607422, 37.195331 ], [ -122.607422, 37.300275 ], [ -122.387695, 37.300275 ] ], [ [ -122.541504, 37.212832 ], [ -122.453613, 37.212832 ], [ -122.453613, 37.282795 ], [ -122.541504, 37.282795 ], [ -122.541504, 37.212832 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 3, "x": 1, "y": 3 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.453613, 37.848833 ], [ -122.552490, 37.952861 ] ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.695312, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.701207 ], [ -122.497559, 37.744657 ], [ -122.398682, 37.701207 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.544577 ], [ -122.398682, 37.396346 ], [ -122.794189, 37.396346 ], [ -122.794189, 37.544577 ], [ -122.398682, 37.544577 ] ], [ [ -122.695312, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.695312, 37.501010 ], [ -122.695312, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.695312, 37.300275 ], [ -122.695312, 37.195331 ], [ -122.904053, 37.195331 ], [ -122.904053, 37.300275 ], [ -122.695312, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.195331 ], [ -122.596436, 37.195331 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.552490, 37.221580 ], [ -122.453613, 37.221580 ], [ -122.453613, 37.282795 ], [ -122.552490, 37.282795 ], [ -122.552490, 37.221580 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 4, "x": 2, "y": 6 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.497559, 37.900865 ], [ -122.448120, 37.848833 ], [ -122.546997, 37.948529 ] ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.596824 ], [ -122.596436, 37.649034 ] ], [ [ -122.497559, 37.596824 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.596436, 37.696861 ], [ -122.497559, 37.749001 ], [ -122.398682, 37.696861 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.448697 ], [ -122.497559, 37.448697 ], [ -122.497559, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.448697 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.898560, 37.199706 ], [ -122.898560, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.596436, 37.199706 ], [ -122.596436, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.546997, 37.217206 ], [ -122.448120, 37.217206 ], [ -122.448120, 37.278424 ], [ -122.546997, 37.278424 ], [ -122.546997, 37.217206 ] ] ] ] } }
+] }
+] }
+,
+{ "type": "FeatureCollection", "properties": { "zoom": 5, "x": 5, "y": 12 }, "features": [
+{ "type": "FeatureCollection", "properties": { "layer": "roundtrip", "version": 2, "extent": 4096 }, "features": [
+{ "type": "Feature", "id": 2, "properties": { "active": false, "count": -200, "kind": "point", "name": "multipoint", "ratio": -0.25 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ -122.500305, 37.900865 ], [ -122.450867, 37.851001 ], [ -122.549744, 37.950695 ] ] } }
+,
+{ "type": "Feature", "id": 1, "properties": { "active": true, "count": 100, "kind": "point", "name": "point", "nested": "{\"a\":1,\"b\":\"two\"}", "ratio": 1.5 }, "geometry": { "type": "Point", "coordinates": [ -122.398682, 37.798933 ] } }
+,
+{ "type": "Feature", "properties": { "kind": "point", "name": "no id", "unicode": "påíñtß 堤防" }, "geometry": { "type": "Point", "coordinates": [ -122.349243, 37.749001 ] } }
+,
+{ "type": "Feature", "id": 4, "properties": { "count": 4000000000, "kind": "line", "name": "multiline", "ratio": 0.125 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ -122.700806, 37.599000 ], [ -122.599182, 37.649034 ] ], [ [ -122.500305, 37.599000 ], [ -122.398682, 37.649034 ] ] ] } }
+,
+{ "type": "Feature", "id": 3, "properties": { "count": 300, "kind": "line", "name": "line", "ratio": 2 }, "geometry": { "type": "LineString", "coordinates": [ [ -122.599182, 37.699034 ], [ -122.500305, 37.749001 ], [ -122.398682, 37.699034 ] ] } }
+,
+{ "type": "Feature", "id": 5, "properties": { "active": true, "count": 500, "kind": "polygon", "name": "polygon with hole", "ratio": 3.25 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.398682, 37.548933 ], [ -122.398682, 37.400710 ], [ -122.799683, 37.400710 ], [ -122.799683, 37.548933 ], [ -122.398682, 37.548933 ] ], [ [ -122.700806, 37.450877 ], [ -122.500305, 37.450877 ], [ -122.500305, 37.501010 ], [ -122.700806, 37.501010 ], [ -122.700806, 37.450877 ] ] ] } }
+,
+{ "type": "Feature", "id": 6, "properties": { "count": 600, "kind": "polygon", "name": "multipolygon" }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -122.700806, 37.300275 ], [ -122.700806, 37.199706 ], [ -122.901306, 37.199706 ], [ -122.901306, 37.300275 ], [ -122.700806, 37.300275 ] ] ], [ [ [ -122.398682, 37.300275 ], [ -122.398682, 37.199706 ], [ -122.599182, 37.199706 ], [ -122.599182, 37.300275 ], [ -122.398682, 37.300275 ] ], [ [ -122.549744, 37.219393 ], [ -122.450867, 37.219393 ], [ -122.450867, 37.280609 ], [ -122.549744, 37.280609 ], [ -122.549744, 37.219393 ] ] ] ] } }
+] }
+] }
+] }

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -1636,7 +1636,7 @@ int main(int argc, char **argv) {
 		st.maxlon2 = st.maxlon;
 	}
 
-	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat2, st.minlon2, st.maxlat2, st.maxlon2, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, true, description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies, st.maxzoom, 2.5, 1);
+	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat2, st.minlon2, st.maxlat2, st.maxlon2, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, "pbf", description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies, st.maxzoom, 2.5, 1);
 
 	if (outdb != NULL) {
 		mbtiles_write_metadata(outdb, m, true);

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -24,6 +24,7 @@
 #include <math.h>
 #include <pthread.h>
 #include "mvt.hpp"
+#include "mlt.hpp"
 #include "projection.hpp"
 #include "mbtiles.hpp"
 #include "geometry.hpp"
@@ -871,7 +872,7 @@ void *join_worker(void *v) {
 		}
 
 		if (anything) {
-			std::string pbf = outtile.encode();
+			std::string pbf = encode_tile(outtile, output_format);
 			std::string compressed;
 
 			if (!pC) {
@@ -958,7 +959,7 @@ void dispatch_tasks(std::map<zxy, std::vector<std::string>> &tasks, std::vector<
 			if (outdb != NULL) {
 				mbtiles_write_tile(outdb, ai->first.z, ai->first.x, ai->first.y, ai->second.data(), ai->second.size());
 			} else if (outdir != NULL) {
-				dir_write_tile(outdir, ai->first.z, ai->first.x, ai->first.y, ai->second);
+				dir_write_tile(outdir, ai->first.z, ai->first.x, ai->first.y, ai->second, tile_format_extension(output_format));
 			}
 		}
 	}
@@ -1335,6 +1336,9 @@ int main(int argc, char **argv) {
 		{"tile-stats-sample-values-limit", required_argument, 0, '~'},
 		{"tile-stats-values-limit", required_argument, 0, '~'},
 		{"unidecode-data", required_argument, 0, '~'},
+		{"output-format", required_argument, 0, '~'},
+		{"pretessellate", no_argument, 0, '~'},
+		{"no-mlt-feature-sort", no_argument, 0, '~'},
 
 		{0, 0, 0, 0},
 	};
@@ -1515,6 +1519,12 @@ int main(int argc, char **argv) {
 				exclude_all_tile_attributes = true;
 			} else if (strcmp(opt, "exclude-all-tile-geometries") == 0) {
 				exclude_all_tile_geometries = true;
+			} else if (strcmp(opt, "output-format") == 0) {
+				set_output_format(argv, optarg);
+			} else if (strcmp(opt, "pretessellate") == 0) {
+				mlt_pretessellate = true;
+			} else if (strcmp(opt, "no-mlt-feature-sort") == 0) {
+				mlt_sort_features = false;
 			} else {
 				fprintf(stderr, "%s: Unrecognized option --%s\n", argv[0], opt);
 				exit(EXIT_ARGS);
@@ -1636,7 +1646,7 @@ int main(int argc, char **argv) {
 		st.maxlon2 = st.maxlon;
 	}
 
-	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat2, st.minlon2, st.maxlat2, st.maxlon2, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, "pbf", description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies, st.maxzoom, 2.5, 1);
+	metadata m = make_metadata(name.c_str(), st.minzoom, st.maxzoom, st.minlat, st.minlon, st.maxlat, st.maxlon, st.minlat2, st.minlon2, st.maxlat2, st.maxlon2, st.midlat, st.midlon, attribution.size() != 0 ? attribution.c_str() : NULL, layermap, tile_format_name(output_format), description.c_str(), !pg, attribute_descriptions, "tile-join", generator_options, strategies, st.maxzoom, 2.5, 1);
 
 	if (outdb != NULL) {
 		mbtiles_write_metadata(outdb, m, true);

--- a/tile.cpp
+++ b/tile.cpp
@@ -39,6 +39,7 @@
 #include "serial.hpp"
 #include "options.hpp"
 #include "main.hpp"
+#include "mlt.hpp"
 #include "write_json.hpp"
 #include "milo/dtoa_milo.h"
 #include "evaluator.hpp"
@@ -2847,7 +2848,12 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			}
 
 			std::string compressed;
-			std::string pbf = tile.encode();
+			std::string pbf;
+			if (output_format == OUTPUT_MLT) {
+				pbf = encode_as_mlt(tile, mlt_sort_features, mlt_pretessellate);
+			} else {
+				pbf = tile.encode();
+			}
 
 			tile.layers.clear();
 
@@ -3022,7 +3028,8 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				if (outdb != NULL) {
 					mbtiles_write_tile(outdb, z, tx, ty, compressed.data(), compressed.size());
 				} else if (outdir != NULL) {
-					dir_write_tile(outdir, z, tx, ty, compressed);
+					const char *tile_ext = (output_format == OUTPUT_MLT) ? ".mlt" : ".pbf";
+					dir_write_tile(outdir, z, tx, ty, compressed, tile_ext);
 				}
 
 				if (pthread_mutex_unlock(&db_lock) != 0) {

--- a/tile.cpp
+++ b/tile.cpp
@@ -2854,12 +2854,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 			}
 
 			std::string compressed;
-			std::string pbf;
-			if (output_format == OUTPUT_MLT) {
-				pbf = encode_as_mlt(tile, mlt_sort_features, mlt_pretessellate);
-			} else {
-				pbf = tile.encode();
-			}
+			std::string pbf = encode_tile(tile, output_format);
 
 			tile.layers.clear();
 
@@ -3034,8 +3029,7 @@ long long write_tile(decompressor *geoms, std::atomic<long long> *geompos_in, ch
 				if (outdb != NULL) {
 					mbtiles_write_tile(outdb, z, tx, ty, compressed.data(), compressed.size());
 				} else if (outdir != NULL) {
-					const char *tile_ext = (output_format == OUTPUT_MLT) ? ".mlt" : ".pbf";
-					dir_write_tile(outdir, z, tx, ty, compressed, tile_ext);
+					dir_write_tile(outdir, z, tx, ty, compressed, tile_format_extension(output_format));
 				}
 
 				if (pthread_mutex_unlock(&db_lock) != 0) {


### PR DESCRIPTION
## Summary

Builds on #393 (MLT output format) and makes MLT a format the whole toolchain can read and write, so a tileset written with `--output-format=mlt` is a first-class tileset rather than a dead end. It also makes MLT support optional at build time, so #393's new submodule and `cmake` dependency don't become mandatory for everyone.

- `tippecanoe-decode`, `tile-join`, and `tippecanoe-overzoom` now **read** MapLibre Tiles from mbtiles files, PMTiles archives, tile directories, and individual tile files. No option is needed: `mvt_tile::decode()` detects the encoding from the tile data and dispatches, so every place tippecanoe already reads a vector tile gained MLT support at once.
- `tile-join` and `tippecanoe-overzoom` now **write** MLT, with the same `--output-format`, `--pretessellate`, and `--no-mlt-feature-sort` options tippecanoe has. Either tool reads whichever format its sources are in regardless of what it is writing, so this also gives you MVT ⇄ MLT conversion of an existing tileset.
- **`make MLT=0`** builds without MLT at all — no submodule, no `cmake`, no dependencies beyond the ones MVT already needed.

It also fixes two encoding problems in #393 that only became visible once the tiles could be read back.

This branch contains #393 merged into `main` (there was a conflict in the `test` target), plus four commits of its own.

## Reading MLT

**The decoder** (`mlt_decode.cpp`)

- Builds the `mlt-cpp` decoder target from the vendored `maplibre-tile-spec` submodule alongside the encoder, and links it into `tippecanoe-decode`, `tile-join`, `tippecanoe-overzoom`, `unit`, and `tippecanoe`.
- `is_mlt()` sniffs the (already decompressed) tile: an MLT tile is a varint layer length followed by a varint layer tag whose only defined value is 1, while an MVT tile is a protobuf whose only field is the repeated layer field 3, so it starts with `0x1a` followed by a layer length that can never be as short as the single byte needed to look like an MLT layer tag.
- `decode_mlt()` converts an `mlt::MapLibreTile` to an `mvt_tile`: geometry (points, multipoints, linestrings, multilinestrings, polygons, and multipolygons, with the explicitly closed MLT rings turned back into MVT `closepath` rings), feature ids, and typed property columns. Attribute names are sorted, since MLT holds property columns in an unordered map.
- Malformed tiles report the decoder's error and fail the tile rather than crashing.

**Reading `.mlt` files out of tile directories** (`dirtiles.cpp`)

`enumerate_dirtiles()` recognized `.mlt` names but still recorded `.pbf` as the extension to read them back with, so `tippecanoe-decode` and `tile-join` failed with "No such file or directory" on an MLT directory. It now records whichever extension the tile actually uses.

## Writing MLT

`tile-join` writes the selected format to mbtiles files, PMTiles archives, and tile directories, naming the directory tiles and the tileset metadata `format` accordingly. `tippecanoe-overzoom` writes it to its output tile.

The format selection and the MLT encoder options moved out of `main.cpp`, where they were tippecanoe-only, into `mlt.cpp` where all three tools share them, along with an `encode_tile()` that encodes a tile in the selected format. `overzoom()` takes the format as a parameter rather than reading the global, because `tile-join` also calls it internally to rescale tiles that get re-encoded afterward, and those intermediate tiles should stay MVT.

## Building without MLT

`make MLT=0` compiles with `-DNO_MLT`, skips the submodule and its cmake build entirely, and drops the MLT tests from `make test`. It builds from a checkout with no submodules at all.

Everything that touches the MLT library is behind the `#ifdef`, and that's confined to the two files written for it. The option parsing and the tile format helpers compile either way, so nothing else needs to know about the distinction:

- `--output-format=mlt` reports that the build has no MLT support, rather than being an unrecognized value.
- A tile recognized as MLT reports the same, rather than being misparsed as a protobuf — the format sniffing itself needs no library.

A CI job builds and tests this configuration from a checkout without submodules so it can't quietly stop working.

## Encoding fixes carried over from #393

**Keeping attribute types through the round trip** (`mlt.cpp`)

An MLT property column has one type for the whole layer, while MVT values are individually typed. Converting each value independently meant a column holding both integers and doubles — `gdp_md_est` in `tests/ne_110m_admin_0_countries`, for instance — hit the encoder's fallback and came back as strings like `"904.200000"`. Each attribute's values are now summarized across the layer first and given a single type that can hold all of them, so mixed integer/floating columns become doubles and only genuinely mixed columns (numbers with strings, or booleans with numbers) fall back to strings. That last case is inherent to MLT's typed columns and is noted in the README.

**Keeping nested JSON attributes as JSON text** (`mlt.cpp`)

#393 encoded JSON-object-valued attributes as MLT struct columns. Struct children can only be strings, and the decoder flattens them into `column name + child name`, so an attribute `meta` holding `{"en": "one", "de": "eins"}` came back as two attributes named `metaen` and `metade`. Nested JSON now stays JSON text in the MLT tile, the way MVT carries it, and round-trips exactly.

## Tests

Two new targets wired into `make test`, both against a fixture with points, multipoints, linestrings, multilinestrings, a polygon with a hole, a multipolygon, mixed attribute types, nested JSON, non-ASCII strings, and a feature with no id:

- `mlt-decode-test` — decoding MLT from an mbtiles file, from a tile directory, through `tile-join`, and through `tippecanoe-overzoom`.
- `mlt-output-test` — `tile-join` writing MLT to an mbtiles file and to a tile directory, and `tippecanoe-overzoom` writing MLT. The overzoom case is compared against the same standard as the MLT-in/MVT-out case in `mlt-decode-test`, so it also asserts that converting in either direction yields the same features.

Beyond the checked-in tests, every GeoJSON input under `tests/` was tiled twice — once as MVT, once as MLT — and both decodes compared feature by feature. Geometry, feature ids, and feature counts match exactly everywhere. Attributes match everywhere except the three fixtures that deliberately put more than one type in a single attribute (`tests/attribute-type`, `tests/feature-filter`, `tests/stringid`), where MLT's typed columns force strings. `--pretessellate`, `--no-mlt-feature-sort`, and `-pC` were each checked separately and all round-trip identically, as did `tile-join --output-format=mlt` to mbtiles, PMTiles, and directory output, with and without `--overzoom`.

`make test` passes, and so does `make MLT=0 test` with the submodule directory removed from the working tree entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxhELiLtpUFwrPSWwTYdHG