### PR TITLE
Remove tests/pbf/merged-dedup.pbf in the overzoom-test cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ overzoom-test: tippecanoe-overzoom
 	./tippecanoe-overzoom -b0 --deduplicate-by-id -o tests/pbf/merged-dedup.pbf -t 1/1/0 tests/pbf/1.json.dir/0/0/0.pbf 0/0/0 tests/pbf/2.json.dir/0/0/0.pbf 0/0/0
 	./tippecanoe-decode tests/pbf/merged-dedup.pbf 1 1 0 > tests/pbf/merged-dedup.pbf.json.check
 	cmp tests/pbf/merged-dedup.pbf.json.check tests/pbf/merged-dedup.pbf.json
-	rm -r tests/pbf/1.json.dir tests/pbf/2.json.dir tests/pbf/merged-nodedup.pbf tests/pbf/merged-nodedup.pbf.json.check tests/pbf/merged-dedup.pbf.json.check
+	rm -r tests/pbf/1.json.dir tests/pbf/2.json.dir tests/pbf/merged-nodedup.pbf tests/pbf/merged-nodedup.pbf.json.check tests/pbf/merged-dedup.pbf tests/pbf/merged-dedup.pbf.json.check
 
 join-test: tippecanoe tippecanoe-decode tile-join
 	./tippecanoe -q -f -z12 -o tests/join-population/tabblock_06001420.mbtiles -YALAND10:'Land area' -L'{"file": "tests/join-population/tabblock_06001420.json", "description": "population"}'


### PR DESCRIPTION
The deduplicate-by-id case of `overzoom-test` writes six artifacts, but its cleanup line removes only five. `tests/pbf/merged-dedup.pbf`, created by the `--deduplicate-by-id` overzoom run, is the one left out — while its decoded `.json.check` counterpart *is* removed, which is what makes the omission look accidental rather than deliberate.

The effect is that a full `make test` leaves an untracked file in the working tree. It shows up as spurious `git status` noise and can be committed by accident.

## Verification

Ran `make overzoom-test` both ways:

| | result |
|---|---|
| old cleanup line | `?? tests/pbf/merged-dedup.pbf` left behind |
| new cleanup line | working tree clean |

The target passes either way — the change only affects which paths `rm` is given, and the file is created unconditionally just above, so the `rm` cannot start failing on a missing path.

## Scope

No CHANGELOG entry and no version bump: this touches only the test harness, and nothing about a released build changes. That also keeps this clear of the `2.81.1` entry in #411, so the two can merge in either order without conflicting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcSXLjtokxioaBCCwGTEv1)_