### PR TITLE
Keep tippecanoe's own errors from being reported as protobuf errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   before. Along the way this fixes a leaked `z_stream` when `compress()`
   failed and two `exit()` calls that could run from a destructor or from
   `mvt_value`'s hash function.
+* Keep reporting a tile that fails to decode as `EXIT_MVT`, and report why.
+  Now that decoding failures throw, the `catch` meant for protozero's
+  exceptions was catching tippecanoe's own as well, replacing their exit
+  status and message with `EXIT_PROTOBUF` and a generic "PBF decoding
+  error".
 * Add `--drop-by-attribute-as-needed=`*attribute* to drop the features with
   the lowest values of a numeric attribute from oversized tiles, and
   `--drop-by-attribute-order=desc` to drop the highest values instead.

--- a/clip.cpp
+++ b/clip.cpp
@@ -1230,6 +1230,10 @@ std::string overzoom(std::vector<input_tile> const &tiles, int nz, int nx, int n
 			if (!tile.decode(t.tile, was_compressed)) {
 				throw_tippecanoe_error(EXIT_MVT, "Couldn't parse tile %d/%u/%u", t.z, t.x, t.y);
 			}
+		} catch (tippecanoe_error &e) {
+			// a tippecanoe_error is a std::exception, so it would
+			// otherwise be caught below and reattributed to protobuf
+			throw;
 		} catch (std::exception const &e) {
 			throw_tippecanoe_error(EXIT_PROTOBUF, "PBF decoding error in tile %d/%u/%u", t.z, t.x, t.y);
 		}

--- a/decode.cpp
+++ b/decode.cpp
@@ -102,6 +102,10 @@ void handle(std::string message, int z, unsigned x, unsigned y, std::set<std::st
 			fprintf(stderr, "Couldn't parse tile %d/%u/%u\n", z, x, y);
 			exit(EXIT_MVT);
 		}
+	} catch (tippecanoe_error &e) {
+		// a tippecanoe_error is a std::exception, so it would
+		// otherwise be caught below and reattributed to protobuf
+		throw;
 	} catch (std::exception const &e) {
 		fprintf(stderr, "PBF decoding error in tile %d/%u/%u\n", z, x, y);
 		exit(EXIT_PROTOBUF);

--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -108,6 +108,12 @@ void append_tile(std::string message, int z, unsigned x, unsigned y, std::map<st
 			fprintf(stderr, "Couldn't decompress tile %d/%u/%u\n", z, x, y);
 			exit(EXIT_MVT);
 		}
+	} catch (tippecanoe_error &e) {
+		// a tippecanoe_error is a std::exception, so without this it
+		// would be caught below and reattributed to protobuf. It can't
+		// be rethrown either, since this runs on a worker thread.
+		fprintf(stderr, "%s\n", e.what());
+		exit(e.exit_code);
 	} catch (std::exception const &e) {
 		fprintf(stderr, "PBF decoding error in tile %d/%u/%u\n", z, x, y);
 		exit(EXIT_MVT);
@@ -749,6 +755,11 @@ struct tileset_reader {
 				fprintf(stderr, "Couldn't parse tile %lld/%lld/%lld\n", tile.z, tile.x, tile.y);
 				exit(EXIT_MVT);
 			}
+		} catch (tippecanoe_error &e) {
+			// a tippecanoe_error is a std::exception, so without this
+			// it would be caught below and reattributed to protobuf
+			fprintf(stderr, "%s\n", e.what());
+			exit(e.exit_code);
 		} catch (std::exception const &e) {
 			fprintf(stderr, "PBF decoding error in tile %lld/%lld/%lld\n", tile.z, tile.x, tile.y);
 			exit(EXIT_PROTOBUF);


### PR DESCRIPTION
Follow-up to #413; based on that branch, so please merge it first. The diff against it is four `catch` clauses and a changelog entry.

## The problem

A tile that fails to decode is reported with `EXIT_MVT`, while a tile that protozero throws on is reported with `EXIT_PROTOBUF`. Four places wrap a decode in a try to tell those apart:

```c
try {
        if (!tile.decode(message, was_compressed)) {
                ... exit(EXIT_MVT);
        }
} catch (std::exception const &e) {
        fprintf(stderr, "PBF decoding error in tile %d/%u/%u\n", z, x, y);
        exit(EXIT_PROTOBUF);
}
```

`tippecanoe_error` is a `std::runtime_error`, so once #413 makes `mvt_tile::decode()` throw rather than exit, that `catch` starts catching tippecanoe's own errors too. A tile that fails to decompress now reports `EXIT_PROTOBUF` and "PBF decoding error in tile z/x/y" instead of `EXIT_MVT` and "Tile decompression failed" — the wrong status and a message that points at the wrong layer of the stack. In `overzoom()` the throw and the catch that swallows it are eight lines apart.

## The fix

Catch `tippecanoe_error` first at all four sites. In `overzoom()` (clip.cpp) and in tippecanoe-decode it is rethrown for `main()` to report.

In tile-join it can't be rethrown: `append_tile()` runs inside `join_worker()`, a pthread entry point, and an exception escaping a thread function calls `std::terminate()` rather than exiting. Both tile-join sites report the message and exit with the error's own status instead, which is what the surrounding code already does.

## Testing

`make -j8` builds with no new warnings and `make test` passes (10813 assertions in 7 test cases). No test covers these paths, which is why the regression is invisible to CI in #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuCSVGssWNUCpVEE8Yp5HT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuCSVGssWNUCpVEE8Yp5HT)_